### PR TITLE
Make closeTrustline function public

### DIFF
--- a/contracts/CurrencyNetwork.sol
+++ b/contracts/CurrencyNetwork.sol
@@ -352,6 +352,29 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
     }
 
     /**
+     * @notice `msg.sender` closes a trustline with `_otherParty`
+     * For this to succeed the balance of this trustline needs to be zero
+     * @param _otherParty The other party of the trustline agreement
+     * @return true, if the trustline was closed
+     */
+    function closeTrustline(
+        address _otherParty
+    )
+        external
+        returns (bool _success)
+    {
+
+        address from = msg.sender;
+
+        _closeTrustline(
+            from,
+            _otherParty
+        );
+
+        return true;
+    }
+
+    /**
      * @dev The ERC20 Token balance for the spender. This is different from the balance within a trustline.
      *      In Trustlines this is the spendable amount
      * @param _owner The address from which the balance will be retrieved
@@ -756,9 +779,11 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         internal
     {
         TrustlineBalances memory balances = _loadTrustlineBalances(_from, _otherParty);
-        assert(balances.balance == 0);
+        require(balances.balance == 0);
 
-        delete trustlines[uniqueIdentifier(_from, _otherParty)];
+        bytes32 uniqueId = uniqueIdentifier(_from, _otherParty);
+        delete requestedTrustlineUpdates[uniqueId];
+        delete trustlines[uniqueId];
         friends[_from].remove(_otherParty);
         friends[_otherParty].remove(_from);
         emit TrustlineUpdate(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import eth_tester.backends.pyevm.main
 
 @pytest.fixture(scope="session", autouse=True)
 def increase_gas_limit():
-    """increate eth_tester's GAS_LIMIT
+    """increase eth_tester's GAS_LIMIT
 
     Otherwise we can't deploy our contract"""
     assert eth_tester.backends.pyevm.main.GENESIS_GAS_LIMIT < 6 * 10 ** 6

--- a/tests/test_close_trustline.py
+++ b/tests/test_close_trustline.py
@@ -2,6 +2,9 @@
 
 import time
 import pytest
+
+import eth_tester.exceptions
+
 from tldeploy.core import deploy_network
 
 
@@ -74,6 +77,38 @@ def ensure_trustline_closed(contract, address1, address2):
 
     assert address2 not in contract.functions.getFriends(address1).call()
     assert address1 not in contract.functions.getFriends(address2).call()
+
+
+def test_close_trustline(currency_network_contract,
+                         accounts):
+    contract = currency_network_contract
+
+    contract.functions.updateTrustline(accounts[1], 1000, 1000, 0, 0).transact({'from': accounts[0]})
+    contract.functions.updateTrustline(accounts[0], 1000, 1000, 0, 0).transact({'from': accounts[1]})
+
+    contract.functions.closeTrustline(accounts[1]).transact({'from': accounts[0]})
+    ensure_trustline_closed(contract, accounts[0], accounts[1])
+
+
+def test_cannot_close_with_balance(currency_network_contract,
+                                   accounts):
+    contract = currency_network_contract
+
+    contract.functions.updateTrustline(accounts[1], 1000, 1000, 0, 0).transact({'from': accounts[0]})
+    contract.functions.updateTrustline(accounts[0], 1000, 1000, 0, 0).transact({'from': accounts[1]})
+
+    contract.functions.transfer(accounts[1], 20, 1, [accounts[1]]).transact({'from': accounts[0]})
+    with pytest.raises(eth_tester.exceptions.TransactionFailed):
+        contract.functions.closeTrustline(accounts[1]).transact({'from': accounts[0]})
+
+
+def test_cannot_reopen_closed_trustline(currency_network_contract,
+                                        accounts):
+    contract = currency_network_contract
+    contract.functions.updateTrustline(accounts[1], 1000, 1000, 0, 0).transact({'from': accounts[0]})
+    contract.functions.closeTrustline(accounts[1]).transact({'from': accounts[0]})
+    contract.functions.updateTrustline(accounts[0], 1000, 1000, 0, 0).transact({'from': accounts[1]})
+    ensure_trustline_closed(contract, accounts[0], accounts[1])
 
 
 def test_close_trustline_negative_balance(

--- a/tests/test_gas_costs.py
+++ b/tests/test_gas_costs.py
@@ -124,3 +124,14 @@ def test_cost_update_reduce_need_no_accept_trustline(web3, currency_network_cont
     assert contract.functions.creditline(A, B).call() == 99
     gas_cost = get_gas_costs(web3, tx_hash)
     report_gas_costs(table, 'Reduce Trustline', gas_cost, limit=66000)
+
+
+def test_cost_close_trustline(web3, currency_network_contract_with_trustlines, accounts, table):
+    contract = currency_network_contract_with_trustlines
+    A, B, *rest = accounts
+    contract.functions.transfer(B, 1, 0, [B]).transact({"from": A})
+    assert contract.functions.balance(A, B).call() == 0
+
+    tx_hash = contract.functions.closeTrustline(B).transact({"from": A})
+    gas_cost = get_gas_costs(web3, tx_hash)
+    report_gas_costs(table, 'Close Trustline', gas_cost, limit=55000)


### PR DESCRIPTION
To allow a user to just close their trustline if the balance is already
zero we make the closeTrustline function public available

Closes #151