### PR TITLE
Upgrade the contracts to solidity 0.5.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,9 @@ templates:
 executors:
   ubuntu-builder:
     docker:
-      - image: trustlines/builder:master9
+      - image: trustlines/builder:master25
         environment:
-          - SOLC_VERSION=v0.4.25
+          - SOLC_VERSION=v0.5.8
     working_directory: ~/repo
     environment:
       DOCKER_REPO: trustlines/contracts

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get -y update && \
     apt-get -y install --no-install-recommends libssl-dev curl python3 python3-distutils libpq5 ca-certificates \
                pkg-config libsecp256k1-dev python3-dev python3-venv git build-essential libpq-dev && \
     rm -rf /var/lib/apt/lists/* && \
-    curl -L -o /usr/bin/solc https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux && \
+    curl -L -o /usr/bin/solc https://github.com/ethereum/solidity/releases/download/v0.5.8/solc-static-linux && \
     chmod +x /usr/bin/solc
 
 # cache /opt/contracts with requirements installed

--- a/contracts/CurrencyNetwork.sol
+++ b/contracts/CurrencyNetwork.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.8;
 
 
 import "./lib/it_set_lib.sol";
@@ -127,8 +127,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
      *         intermediaries, unless the transaction exclusively reduces balances
      */
     function init(
-        string _name,
-        string _symbol,
+        string calldata _name,
+        string calldata _symbol,
         uint8 _decimals,
         uint16 _capacityImbalanceFeeDivisor,
         int16 _defaultInterestRate,
@@ -169,7 +169,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         address _to,
         uint64 _value,
         uint64 _maxFee,
-        address[] _path
+        address[] calldata _path
     )
         external
         returns (bool _success)
@@ -202,7 +202,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         address _to,
         uint64 _value,
         uint64 _maxFee,
-        address[] _path
+        address[] calldata _path
     )
         external
         returns (bool success)
@@ -236,7 +236,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         address _to,
         uint64 _value,
         uint64 _maxFee,
-        address[] _path
+        address[] calldata _path
     )
     external
     returns (bool _success)
@@ -252,7 +252,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
             emit Transfer(
                 msg.sender,
                 _to,
-                _value);
+                _value
+            );
         }
     }
 
@@ -492,7 +493,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
     function closeTrustlineByTriangularTransfer(
         address _otherParty,
         uint32 _maxFee,
-        address[] _path
+        address[] calldata _path
     )
         external
     {
@@ -557,24 +558,12 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         _balance = trustlineBalances.balance;
     }
 
-    function getFriends(address _user) public view returns (address[]) {
+    function getFriends(address _user) public view returns (address[] memory) {
         return friends[_user].list;
     }
 
-    function getUsers() public view returns (address[]) {
+    function getUsers() public view returns (address[] memory) {
         return users.list;
-    }
-
-    function name() public view returns (string) {
-        return name;
-    }
-
-    function symbol() public view returns (string) {
-        return symbol;
-    }
-
-    function decimals() public view returns (uint8) {
-        return decimals;
     }
 
     // This function transfers value over this trustline
@@ -621,7 +610,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         address _to,
         uint64 _value,
         uint64 _maxFee,
-        address[] _path
+        address[] memory _path
     )
         internal
         returns (bool)
@@ -699,7 +688,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         address _to,
         uint64 _value,
         uint64 _maxFee,
-        address[] _path
+        address[] memory _path
     )
         internal
         returns (bool)
@@ -806,7 +795,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         address _from,
         address _otherParty,
         uint32 _maxFee,
-        address[] _path)
+        address[] memory _path)
         internal
     {
         Trustline memory trustline = _loadTrustline(_from, _otherParty);
@@ -901,14 +890,14 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         addToUsersAndFriends(_a, _b);
     }
 
-    function _loadTrustline(address _a, address _b) internal view returns (Trustline) {
+    function _loadTrustline(address _a, address _b) internal view returns (Trustline memory) {
         Trustline memory trustline;
         trustline.agreement = _loadTrustlineAgreement(_a, _b);
         trustline.balances = _loadTrustlineBalances(_a, _b);
         return trustline;
     }
 
-    function _loadTrustlineAgreement(address _a, address _b) internal view returns (TrustlineAgreement) {
+    function _loadTrustlineAgreement(address _a, address _b) internal view returns (TrustlineAgreement memory) {
         TrustlineAgreement memory trustlineAgreement = trustlines[uniqueIdentifier(_a, _b)].agreement;
         TrustlineAgreement memory result;
         if (_a < _b) {
@@ -922,7 +911,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         return result;
     }
 
-    function _loadTrustlineBalances(address _a, address _b) internal view returns (TrustlineBalances) {
+    function _loadTrustlineBalances(address _a, address _b) internal view returns (TrustlineBalances memory) {
         TrustlineBalances memory balances = trustlines[uniqueIdentifier(_a, _b)].balances;
         TrustlineBalances memory result;
         if (_a < _b) {
@@ -980,16 +969,16 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         }
     }
 
-    function _loadTrustlineRequest(address _a, address _b) internal view returns (TrustlineRequest) {
+    function _loadTrustlineRequest(address _a, address _b) internal view returns (TrustlineRequest memory) {
         TrustlineRequest memory trustlineRequest = requestedTrustlineUpdates[uniqueIdentifier(_a, _b)];
         return trustlineRequest;
     }
 
-    function _deleteTrustlineRequest(address _a, address _b) internal view {
+    function _deleteTrustlineRequest(address _a, address _b) internal {
         delete requestedTrustlineUpdates[uniqueIdentifier(_a, _b)];
     }
 
-    function _storeTrustlineRequest(address _a, address _b, TrustlineRequest _trustlineRequest) internal {
+    function _storeTrustlineRequest(address _a, address _b, TrustlineRequest memory _trustlineRequest) internal {
         if (!customInterests) {
             assert(_trustlineRequest.interestRateGiven == defaultInterestRate);
             assert(_trustlineRequest.interestRateReceived == defaultInterestRate);
@@ -1334,9 +1323,9 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
     function uniqueIdentifier(address _a, address _b) internal pure returns (bytes32) {
         require(_a != _b, "Unique identifiers require different addresses");
         if (_a < _b) {
-            return keccak256(_a, _b);
+            return keccak256(abi.encodePacked(_a, _b));
         } else if (_a > _b) {
-            return keccak256(_b, _a);
+            return keccak256(abi.encodePacked(_b, _a));
         }
     }
 
@@ -1348,7 +1337,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         pure
         returns (bytes32)
     {
-        return keccak256(_creditor, _debtor);
+        return keccak256(abi.encodePacked(_creditor, _debtor));
     }
 
 }

--- a/contracts/CurrencyNetworkInterface.sol
+++ b/contracts/CurrencyNetworkInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.5.8;
 
 
 contract CurrencyNetworkInterface {
@@ -7,7 +7,7 @@ contract CurrencyNetworkInterface {
         address _to,
         uint64 _value,
         uint64 _maxFee,
-        address[] _path
+        address[] calldata _path
     )
         external
         returns (bool success);
@@ -17,7 +17,7 @@ contract CurrencyNetworkInterface {
         address _to,
         uint64 _value,
         uint64 _maxFee,
-        address[] _path
+        address[] calldata _path
     )
         external
         returns (bool success);

--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.8;
 
 import "./tokens/Token.sol";
 import "./lib/SafeMath.sol";
@@ -105,8 +105,8 @@ contract Exchange is SafeMath, Destructable {
     /// @param s ECDSA signature parameters s.
     /// @return Total amount of takerToken filled in trade.
     function fillOrder(
-        address[5] orderAddresses,
-        uint[6] orderValues,
+        address[5] memory orderAddresses,
+        uint[6] memory orderValues,
         uint fillTakerTokenAmount,
         bool shouldThrowOnInsufficientBalanceOrAllowance,
         uint8 v,
@@ -198,7 +198,7 @@ contract Exchange is SafeMath, Destructable {
             filledTakerTokenAmount,
             paidMakerFee,
             paidTakerFee,
-            keccak256(order.makerToken, order.takerToken),
+            keccak256(abi.encodePacked(order.makerToken, order.takerToken)),
             order.orderHash
         );
         return filledTakerTokenAmount;
@@ -215,8 +215,8 @@ contract Exchange is SafeMath, Destructable {
     /// @param s ECDSA signature parameters s.
     /// @return Total amount of takerToken filled in trade.
     function fillOrderTrustlines(
-        address[5] orderAddresses,
-        uint[6] orderValues,
+        address[5] memory orderAddresses,
+        uint[6] memory orderValues,
         uint fillTakerTokenAmount,
         address[] memory makerPath,
         address[] memory takerPath,
@@ -337,7 +337,7 @@ contract Exchange is SafeMath, Destructable {
             filledTakerTokenAmount,
             0,
             0,
-            keccak256(order.makerToken, order.takerToken),
+            keccak256(abi.encodePacked(order.makerToken, order.takerToken)),
             order.orderHash
         );
         return filledTakerTokenAmount;
@@ -349,8 +349,8 @@ contract Exchange is SafeMath, Destructable {
     /// @param cancelTakerTokenAmount Desired amount of takerToken to cancel in order.
     /// @return Amount of takerToken cancelled.
     function cancelOrder(
-        address[5] orderAddresses,
-        uint[6] orderValues,
+        address[5] memory orderAddresses,
+        uint[6] memory orderValues,
         uint cancelTakerTokenAmount)
         public
         returns (uint)
@@ -398,7 +398,7 @@ contract Exchange is SafeMath, Destructable {
             order.takerToken,
             getPartialAmount(cancelledTakerTokenAmount, order.takerTokenAmount, order.makerTokenAmount),
             cancelledTakerTokenAmount,
-            keccak256(order.makerToken, order.takerToken),
+            keccak256(abi.encodePacked(order.makerToken, order.takerToken)),
             order.orderHash
         );
         return cancelledTakerTokenAmount;
@@ -416,8 +416,8 @@ contract Exchange is SafeMath, Destructable {
     /// @param r ECDSA signature parameters r.
     /// @param s ECDSA signature parameters s.
     function fillOrKillOrder(
-        address[5] orderAddresses,
-        uint[6] orderValues,
+        address[5] memory orderAddresses,
+        uint[6] memory orderValues,
         uint fillTakerTokenAmount,
         uint8 v,
         bytes32 r,
@@ -447,13 +447,13 @@ contract Exchange is SafeMath, Destructable {
     /// @param r Array of ECDSA signature r parameters.
     /// @param s Array of ECDSA signature s parameters.
     function batchFillOrders(
-        address[5][] orderAddresses,
-        uint[6][] orderValues,
-        uint[] fillTakerTokenAmounts,
+        address[5][] memory orderAddresses,
+        uint[6][] memory orderValues,
+        uint[] memory fillTakerTokenAmounts,
         bool shouldThrowOnInsufficientBalanceOrAllowance,
-        uint8[] v,
-        bytes32[] r,
-        bytes32[] s)
+        uint8[] memory v,
+        bytes32[] memory r,
+        bytes32[] memory s)
         public
     {
         for (uint i = 0; i < orderAddresses.length; i++) {
@@ -477,12 +477,12 @@ contract Exchange is SafeMath, Destructable {
     /// @param r Array of ECDSA signature r parameters.
     /// @param s Array of ECDSA signature s parameters.
     function batchFillOrKillOrders(
-        address[5][] orderAddresses,
-        uint[6][] orderValues,
-        uint[] fillTakerTokenAmounts,
-        uint8[] v,
-        bytes32[] r,
-        bytes32[] s)
+        address[5][] memory orderAddresses,
+        uint[6][] memory orderValues,
+        uint[] memory fillTakerTokenAmounts,
+        uint8[] memory v,
+        bytes32[] memory r,
+        bytes32[] memory s)
         public
     {
         for (uint i = 0; i < orderAddresses.length; i++) {
@@ -507,13 +507,13 @@ contract Exchange is SafeMath, Destructable {
     /// @param s Array of ECDSA signature s parameters.
     /// @return Total amount of fillTakerTokenAmount filled in orders.
     function fillOrdersUpTo(
-        address[5][] orderAddresses,
-        uint[6][] orderValues,
+        address[5][] memory orderAddresses,
+        uint[6][] memory orderValues,
         uint fillTakerTokenAmount,
         bool shouldThrowOnInsufficientBalanceOrAllowance,
-        uint8[] v,
-        bytes32[] r,
-        bytes32[] s)
+        uint8[] memory v,
+        bytes32[] memory r,
+        bytes32[] memory s)
         public
         returns (uint)
     {
@@ -546,9 +546,9 @@ contract Exchange is SafeMath, Destructable {
     /// @param orderValues Array of uint arrays containing individual order values.
     /// @param cancelTakerTokenAmounts Array of desired amounts of takerToken to cancel in orders.
     function batchCancelOrders(
-        address[5][] orderAddresses,
-        uint[6][] orderValues,
-        uint[] cancelTakerTokenAmounts)
+        address[5][] memory orderAddresses,
+        uint[6][] memory orderValues,
+        uint[] memory cancelTakerTokenAmounts)
         public
     {
         for (uint i = 0; i < orderAddresses.length; i++) {
@@ -568,24 +568,26 @@ contract Exchange is SafeMath, Destructable {
     /// @param orderAddresses Array of order's maker, taker, makerToken, takerToken, and feeRecipient.
     /// @param orderValues Array of order's makerTokenAmount, takerTokenAmount, makerFee, takerFee, expirationTimestampInSec, and salt.
     /// @return Keccak-256 hash of order.
-    function getOrderHash(address[5] orderAddresses, uint[6] orderValues)
+    function getOrderHash(address[5] memory orderAddresses, uint[6] memory orderValues)
         public
         view
         returns (bytes32)
     {
         return keccak256(
-            address(this),
-            orderAddresses[0], // maker
-            orderAddresses[1], // taker
-            orderAddresses[2], // makerToken
-            orderAddresses[3], // takerToken
-            orderAddresses[4], // feeRecipient
-            orderValues[0],    // makerTokenAmount
-            orderValues[1],    // takerTokenAmount
-            orderValues[2],    // makerFee
-            orderValues[3],    // takerFee
-            orderValues[4],    // expirationTimestampInSec
-            orderValues[5]     // salt
+            abi.encodePacked(
+                address(this),
+                orderAddresses[0], // maker
+                orderAddresses[1], // taker
+                orderAddresses[2], // makerToken
+                orderAddresses[3], // takerToken
+                orderAddresses[4], // feeRecipient
+                orderValues[0],    // makerTokenAmount
+                orderValues[1],    // takerTokenAmount
+                orderValues[2],    // makerFee
+                orderValues[3],    // takerFee
+                orderValues[4],    // expirationTimestampInSec
+                orderValues[5]     // salt
+            )
         );
     }
 
@@ -607,7 +609,7 @@ contract Exchange is SafeMath, Destructable {
         returns (bool)
     {
         return signer == ecrecover(
-            keccak256("\x19Ethereum Signed Message:\n32", hash),
+            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash)),
             v,
             r,
             s
@@ -661,26 +663,26 @@ contract Exchange is SafeMath, Destructable {
     }
 
     /// @dev Get token balance of an address.
+    /// @dev The called token contract may attempt to change state, but will not be able to due to an added gas limit.
     /// @param token Address of token.
     /// @param owner Address of owner.
     /// @return Token balance of owner.
     function getBalance(address token, address owner)
         internal
-        view  // The called token contract may attempt to change state, but will not be able to due to an added gas limit.
         returns (uint)
     {
         return Token(token).balanceOf.gas(EXTERNAL_QUERY_GAS_LIMIT)(owner); // Limit gas to prevent reentrancy
     }
 
     /// @dev Get allowance of token given to TokenTransferProxy by an address.
+    /// @dev The called token contract may attempt to change state, but will not be able to due to an added gas limit.
     /// @param token Address of token.
     /// @param owner Address of owner.
     /// @return Allowance of token given to TokenTransferProxy by owner.
     function getAllowance(address token, address owner)
         internal
-        view  // The called token contract may attempt to change state, but will not be able to due to an added gas limit.
         returns (uint)
     {
-        return Token(token).allowance.gas(EXTERNAL_QUERY_GAS_LIMIT)(owner, this); // Limit gas to prevent reentrancy
+        return Token(token).allowance.gas(EXTERNAL_QUERY_GAS_LIMIT)(owner, address(this)); // Limit gas to prevent reentrancy
     }
 }

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.8;
 
 import "./lib/ECDSA.sol";
 
@@ -19,7 +19,7 @@ contract Identity {
     }
 
     // This contract can receive ether
-    function () public payable {}
+    function () external payable {}
 
     function init(address _owner) public {
         require(! initialised, "The contract has already been initialised.");
@@ -29,12 +29,12 @@ contract Identity {
 
     function executeTransaction(
         address from,
-        address to,
+        address payable to,
         uint256 value,
-        bytes data,
+        bytes memory data,
         uint256 nonce,
-        bytes extraData,
-        bytes signature
+        bytes memory extraData,
+        bytes memory signature
     )
         public returns (bool _success)
     {
@@ -59,7 +59,7 @@ contract Identity {
             lastNonce++;
         }
 
-        bool status = to.call.value(value)(data); // solium-disable-line security/no-call-value
+        (bool status, bytes memory returnedData) = to.call.value(value)(data); // solium-disable-line
 
         emit TransactionExecution(hash, status);
 
@@ -75,7 +75,7 @@ contract Identity {
 
     }
 
-    function validateSignature(bytes32 hash, bytes _signature) public view returns (bool) {
+    function validateSignature(bytes32 hash, bytes memory _signature) public view returns (bool) {
         address signer = ECDSA.recover(hash, _signature);
         return owner == signer;
     }
@@ -84,9 +84,9 @@ contract Identity {
         address from,
         address to,
         uint256 value,
-        bytes data,
+        bytes memory data,
         uint256 nonce,
-        bytes extraData
+        bytes memory extraData
     )
     internal
     pure

--- a/contracts/lib/Authorizable.sol
+++ b/contracts/lib/Authorizable.sol
@@ -16,7 +16,7 @@
 
 */
 
-pragma solidity ^0.4.11;
+pragma solidity ^0.5.8;
 
 import "./Ownable.sol";
 

--- a/contracts/lib/Destructable.sol
+++ b/contracts/lib/Destructable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.5.8;
 
 import "./Ownable.sol";
 
@@ -12,6 +12,6 @@ import "./Ownable.sol";
 contract Destructable is Ownable {
 
     function destruct() external onlyOwner {
-        selfdestruct(owner);
+        selfdestruct(address(uint160(owner)));
     }
 }

--- a/contracts/lib/ECDSA.sol
+++ b/contracts/lib/ECDSA.sol
@@ -23,7 +23,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.8;
 
 /**
  * @title Elliptic curve signature operations
@@ -38,7 +38,7 @@ library ECDSA {
      * @param hash bytes32 message, the hash is the signed message. What is recovered is the signer address.
      * @param signature bytes signature, the signature is generated using web3.eth.sign()
      */
-    function recover(bytes32 hash, bytes signature) internal pure returns (address) {
+    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {
         bytes32 r;
         bytes32 s;
         uint8 v;

--- a/contracts/lib/Ownable.sol
+++ b/contracts/lib/Ownable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.8;
 
 /*
  * Ownable

--- a/contracts/lib/SafeMath.sol
+++ b/contracts/lib/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.5.8;
 
 
 contract SafeMath {

--- a/contracts/lib/it_set_lib.sol
+++ b/contracts/lib/it_set_lib.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.5.8;
 
 
 /**

--- a/contracts/tests/TestContract.sol
+++ b/contracts/tests/TestContract.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.8;
 
 
 contract TestContract {

--- a/contracts/tests/TestCurrencyNetwork.sol
+++ b/contracts/tests/TestCurrencyNetwork.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.8;
 
 /*
   The sole purpose of this file is to be able to test the internal functions of
@@ -23,7 +23,7 @@ contract TestCurrencyNetwork is CurrencyNetwork {
         address _to,
         uint64 _value,
         uint64 _maxFee,
-        address[] _path)
+        address[] calldata _path)
         external
         returns (bool _success)
     {
@@ -41,7 +41,7 @@ contract TestCurrencyNetwork is CurrencyNetwork {
         address _to,
         uint64 _value,
         uint64 _maxFee,
-        address[] _path)
+        address[] calldata _path)
         external
         returns (bool _success)
     {

--- a/contracts/tests/TestIdentity.sol
+++ b/contracts/tests/TestIdentity.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity ^0.5.8;
 
 /*
   The sole purpose of this file is to be able to test the internal functions of the identity contract
@@ -14,9 +14,9 @@ contract TestIdentity is Identity {
         address from,
         address to,
         uint256 value,
-        bytes data,
+        bytes memory data,
         uint256 nonce,
-        bytes extraHash
+        bytes memory extraHash
     )
         public
         view

--- a/contracts/tokens/DummyToken.sol
+++ b/contracts/tokens/DummyToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.5.8;
 
 import "./../lib/Ownable.sol";
 import "./../lib/SafeMath.sol";
@@ -10,9 +10,9 @@ contract DummyToken is Ownable, StandardToken, SafeMath {
     string public symbol;
     uint public decimals;
 
-    function DummyToken(
-        string _name,
-        string _symbol,
+    constructor(
+        string memory _name,
+        string memory _symbol,
         uint _decimals,
         uint _totalSupply
     )

--- a/contracts/tokens/Receiver_Interface.sol
+++ b/contracts/tokens/Receiver_Interface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.9;
+pragma solidity ^0.5.8;
 
 
 /*
@@ -7,6 +7,6 @@ pragma solidity ^0.4.9;
 
 interface ContractReceiver {
 
-    function tokenFallback(address _from, uint _value, bytes _data) external;
+    function tokenFallback(address _from, uint _value, bytes calldata _data) external;
 
 }

--- a/contracts/tokens/StandardToken.sol
+++ b/contracts/tokens/StandardToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.5.8;
 
 import "./Token.sol";
 
@@ -10,7 +10,7 @@ contract StandardToken is Token {
         if (balances[msg.sender] >= _value && balances[_to] + _value >= balances[_to]) {
             balances[msg.sender] -= _value;
             balances[_to] += _value;
-            Transfer(msg.sender, _to, _value);
+            emit Transfer(msg.sender, _to, _value);
             return true;
         } else {
             return false;
@@ -22,7 +22,7 @@ contract StandardToken is Token {
             balances[_to] += _value;
             balances[_from] -= _value;
             allowed[_from][msg.sender] -= _value;
-            Transfer(_from, _to, _value);
+            emit Transfer(_from, _to, _value);
             return true;
         } else {
             return false;
@@ -35,7 +35,7 @@ contract StandardToken is Token {
 
     function approve(address _spender, uint _value) public returns (bool) {
         allowed[msg.sender][_spender] = _value;
-        Approval(msg.sender, _spender, _value);
+        emit Approval(msg.sender, _spender, _value);
         return true;
     }
 

--- a/contracts/tokens/Token.sol
+++ b/contracts/tokens/Token.sol
@@ -1,10 +1,7 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.5.8;
 
 
 contract Token {
-
-    /// @return total amount of tokens
-    function totalSupply() public view returns (uint supply) {}
 
     /// @param _owner The address from which the balance will be retrieved
     /// @return The balance

--- a/contracts/tokens/UnwETH.sol
+++ b/contracts/tokens/UnwETH.sol
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.5.8;
 
 import "../lib/Authorizable.sol";
 import "../lib/Destructable.sol";
@@ -32,7 +32,7 @@ contract UnwEth is Authorizable, Destructable {
     mapping (address => uint)                       public  balanceOf;
     mapping (address => mapping (address => uint))  public  allowance;
 
-    function() public payable {
+    function() external payable {
         deposit();
     }
 
@@ -49,7 +49,7 @@ contract UnwEth is Authorizable, Destructable {
     }
 
     function totalSupply() public view returns (uint) {
-        return this.balance;
+        return address(this).balance;
     }
 
     function approve(address guy, uint wad) public returns (bool) {
@@ -58,11 +58,11 @@ contract UnwEth is Authorizable, Destructable {
         return true;
     }
 
-    function transfer(address dst, uint wad) public returns (bool) {
+    function transfer(address payable dst, uint wad) public returns (bool) {
         return transferFrom(msg.sender, dst, wad);
     }
 
-    function transferFrom(address src, address dst, uint wad)
+    function transferFrom(address src, address payable dst, uint wad)
         public
         returns (bool)
     {

--- a/tests/test_gas_costs.py
+++ b/tests/test_gas_costs.py
@@ -85,7 +85,7 @@ def test_cost_transfer_2_mediators(
     A, B, C, D, *rest = accounts
     tx_hash = contract.functions.transfer(D, 50, 6, [B, C, D]).transact({"from": A})
     gas_cost = get_gas_costs(web3, tx_hash)
-    report_gas_costs(table, "2 hop transfer", gas_cost, limit=78000)
+    report_gas_costs(table, "2 hop transfer", gas_cost, limit=80000)
 
 
 def test_cost_transfer_3_mediators(
@@ -95,7 +95,7 @@ def test_cost_transfer_3_mediators(
     A, B, C, D, E, *rest = accounts
     tx_hash = contract.functions.transfer(E, 50, 8, [B, C, D, E]).transact({"from": A})
     gas_cost = get_gas_costs(web3, tx_hash)
-    report_gas_costs(table, "3 hop transfer", gas_cost, limit=94000)
+    report_gas_costs(table, "3 hop transfer", gas_cost, limit=97000)
 
 
 def test_cost_first_trustline_request(web3, currency_network_contract, accounts, table):


### PR DESCRIPTION
I replaced `keccak256(a, b)` by `keccak256(abi.encodePacked(a, b))` as I believe it is the expected behaviour of not padding the data before hashing them (and keccak only takes one argument now).

I removed some getter functions that have the same name as a public variable as solc would throw an error saying there is two functions with the same name since it creates a public getter function for public parameters.

I use `address(uint160(owner))` to selfDestruct because it requires a payable address and owner is not payable.