### PR TITLE
Feature/frozen trustlines are locked

### DIFF
--- a/contracts/CurrencyNetwork.sol
+++ b/contracts/CurrencyNetwork.sol
@@ -719,6 +719,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
             }
             // Load trustline only once at the beginning
             Trustline memory trustline = _loadTrustline(sender, _path[i-1]);
+            require(! _isTrustlineFrozen(trustline.agreement), "The path given is incorrect: one trustline in the path is frozen.");
             _applyInterests(trustline);
 
             if (i == _path.length) {
@@ -797,6 +798,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
             }
             // Load trustline only once at the beginning
             Trustline memory trustline = _loadTrustline(sender, _path[i]);
+            require(! _isTrustlineFrozen(trustline.agreement), "The path given is incorrect: one trustline in the path is frozen.");
             _applyInterests(trustline);
 
             int72 balanceBefore = trustline.balances.balance;
@@ -1447,6 +1449,13 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
             // After the transfer: Sender owes to receiver balance;
             return - int(_balanceBefore) * _trustline.agreement.interestRateGiven + int(balance) * _trustline.agreement.interestRateReceived;
         }
+    }
+
+    function _isTrustlineFrozen(TrustlineAgreement memory agreement) internal view returns (bool) {
+        if (isNetworkFrozen) {
+            return true;
+        }
+        return agreement.isFrozen;
     }
 
     function uniqueIdentifier(address _a, address _b) internal pure returns (bytes32) {

--- a/contracts/CurrencyNetwork.sol
+++ b/contracts/CurrencyNetwork.sol
@@ -587,6 +587,9 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
      */
     function spendableTo(address _spender, address _receiver) public view returns (uint remaining) {
         Trustline memory trustline = _loadTrustline(_spender, _receiver);
+        if (_isTrustlineFrozen(trustline.agreement)) {
+            return 0;
+        }
         int72 balance = trustline.balances.balance;
         uint64 creditline = trustline.agreement.creditlineReceived;
         remaining = uint(creditline + balance);

--- a/contracts/CurrencyNetwork.sol
+++ b/contracts/CurrencyNetwork.sol
@@ -64,7 +64,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         uint _creditlineGiven,
         uint _creditlineReceived,
         int _interestRateGiven,
-        int _interestRateReceived
+        int _interestRateReceived,
+        bool _isFrozen
     );
 
     event TrustlineUpdate(
@@ -73,7 +74,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         uint _creditlineGiven,
         uint _creditlineReceived,
         int _interestRateGiven,
-        int _interestRateReceived
+        int _interestRateReceived,
+        bool _isFrozen
     );
 
     event BalanceUpdate(address indexed _from, address indexed _to, int256 _value);
@@ -117,6 +119,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         uint64 creditlineReceived;
         int16 interestRateGiven;
         int16 interestRateReceived;
+        bool isFrozen;
         address initiator;
     }
 
@@ -307,6 +310,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
      * @param _creditlineReceived The creditline limit given _debtor
      * @param _interestRateGiven The interest given by msg.sender
      * @param _interestRateReceived The interest given by _debtor
+     * @param _isFrozen Whether the initiator asks for freezing the trustline
      * @return true, if the credit was successful
      */
     function updateTrustline(
@@ -314,7 +318,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         uint64 _creditlineGiven,
         uint64 _creditlineReceived,
         int16 _interestRateGiven,
-        int16 _interestRateReceived
+        int16 _interestRateReceived,
+        bool _isFrozen
     )
         external
         networkNotFrozen
@@ -329,7 +334,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
             _creditlineGiven,
             _creditlineReceived,
             _interestRateGiven,
-            _interestRateReceived
+            _interestRateReceived,
+            _isFrozen
         );
     }
 
@@ -368,12 +374,14 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
      * @param _debtor The other party of the trustline agreement
      * @param _creditlineGiven The creditline limit given by msg.sender
      * @param _creditlineReceived The creditline limit given _debtor
+     * @param _isFrozen Whether the initiator asks for freezing the trustline
      * @return true, if the credit was successful
      */
     function updateTrustlineDefaultInterests(
         address _debtor,
         uint64 _creditlineGiven,
-        uint64 _creditlineReceived
+        uint64 _creditlineReceived,
+        bool _isFrozen
     )
         external
         networkNotFrozen
@@ -387,7 +395,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
             _creditlineGiven,
             _creditlineReceived,
             defaultInterestRate,
-            defaultInterestRate
+            defaultInterestRate,
+            _isFrozen
         );
     }
 
@@ -453,6 +462,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         uint64 _creditlineReceived,
         int16 _interestRateGiven,
         int16 _interestRateReceived,
+        bool _isFrozen,
         uint16 _feesOutstandingA,
         uint16 _feesOutstandingB,
         uint32 _mtime,
@@ -482,6 +492,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
             _creditlineReceived,
             _interestRateGiven,
             _interestRateReceived,
+            _isFrozen,
             _feesOutstandingA,
             _feesOutstandingB,
             _mtime,
@@ -498,6 +509,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         address _b,
         uint64 _creditlineGiven,
         uint64 _creditlineReceived,
+        bool _isFrozen,
         uint16 _feesOutstandingA,
         uint16 _feesOutstandingB,
         uint32 _mtime,
@@ -514,6 +526,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
             _creditlineReceived,
             defaultInterestRate,
             defaultInterestRate,
+            _isFrozen,
             _feesOutstandingA,
             _feesOutstandingB,
             _mtime,
@@ -847,7 +860,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
             0,
             0,
             0,
-            0);
+            0,
+            false);
     }
 
     /* close a trustline by doing a triangular transfer
@@ -928,6 +942,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         uint64 _creditlineReceived,
         int16 _interestRateGiven,
         int16 _interestRateReceived,
+        bool _isFrozen,
         uint16 _feesOutstandingA,
         uint16 _feesOutstandingB,
         uint32 _mtime,
@@ -940,6 +955,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         trustlineAgreement.creditlineReceived = _creditlineReceived;
         trustlineAgreement.interestRateGiven = _interestRateGiven;
         trustlineAgreement.interestRateReceived = _interestRateReceived;
+        trustlineAgreement.isFrozen = _isFrozen;
 
         TrustlineBalances memory trustlineBalances;
         trustlineBalances.feesOutstandingA = _feesOutstandingA;
@@ -979,6 +995,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
             result.creditlineGiven = trustlineAgreement.creditlineReceived;
             result.interestRateReceived = trustlineAgreement.interestRateGiven;
             result.interestRateGiven = trustlineAgreement.interestRateReceived;
+            result.isFrozen = trustlineAgreement.isFrozen;
         }
         return result;
     }
@@ -1013,12 +1030,14 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
             storedTrustlineAgreement.creditlineReceived = trustlineAgreement.creditlineReceived;
             storedTrustlineAgreement.interestRateGiven = trustlineAgreement.interestRateGiven;
             storedTrustlineAgreement.interestRateReceived = trustlineAgreement.interestRateReceived;
+            storedTrustlineAgreement.isFrozen = trustlineAgreement.isFrozen;
             storedTrustlineAgreement.padding = trustlineAgreement.padding;
         } else {
             storedTrustlineAgreement.creditlineGiven = trustlineAgreement.creditlineReceived;
             storedTrustlineAgreement.creditlineReceived = trustlineAgreement.creditlineGiven;
             storedTrustlineAgreement.interestRateGiven = trustlineAgreement.interestRateReceived;
             storedTrustlineAgreement.interestRateReceived = trustlineAgreement.interestRateGiven;
+            storedTrustlineAgreement.isFrozen = trustlineAgreement.isFrozen;
             storedTrustlineAgreement.padding = trustlineAgreement.padding;
         }
     }
@@ -1067,6 +1086,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         trustlineRequest.interestRateGiven = _trustlineRequest.interestRateGiven;
         trustlineRequest.interestRateReceived = _trustlineRequest.interestRateReceived;
         trustlineRequest.initiator = _trustlineRequest.initiator;
+        trustlineRequest.isFrozen = _trustlineRequest.isFrozen;
     }
 
     // in this function, it is assumed _creditor is the initator of the trustline update (see _requestTrustlineUpdate())
@@ -1076,7 +1096,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         uint64 _creditlineGiven,
         uint64 _creditlineReceived,
         int16 _interestRateGiven,
-        int16 _interestRateReceived
+        int16 _interestRateReceived,
+        bool _isFrozen
     )
         internal
         returns (bool success)
@@ -1098,7 +1119,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         if (_creditlineGiven <= trustlineAgreement.creditlineGiven &&
             _creditlineReceived <= trustlineAgreement.creditlineReceived &&
             _interestRateGiven <= trustlineAgreement.interestRateGiven &&
-            _interestRateReceived == trustlineAgreement.interestRateReceived) {
+            _interestRateReceived == trustlineAgreement.interestRateReceived &&
+            _isFrozen == trustlineAgreement.isFrozen) {
             _deleteTrustlineRequest(_creditor, _debtor);
             _setTrustline(
                 _creditor,
@@ -1106,7 +1128,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
                 _creditlineGiven,
                 _creditlineReceived,
                 _interestRateGiven,
-                _interestRateReceived
+                _interestRateReceived,
+                _isFrozen
             );
             return true;
         }
@@ -1115,7 +1138,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
 
         // if original initiator is debtor, try to accept request
         if (trustlineRequest.initiator == _debtor) {
-            if (_creditlineReceived <= trustlineRequest.creditlineGiven && _creditlineGiven <= trustlineRequest.creditlineReceived && _interestRateGiven <= trustlineRequest.interestRateReceived && _interestRateReceived == trustlineRequest.interestRateGiven) {
+            if (_creditlineReceived <= trustlineRequest.creditlineGiven && _creditlineGiven <= trustlineRequest.creditlineReceived && _interestRateGiven <= trustlineRequest.interestRateReceived && _interestRateReceived == trustlineRequest.interestRateGiven && _isFrozen == trustlineRequest.isFrozen) {
                 _deleteTrustlineRequest(_creditor, _debtor);
                 // _debtor and _creditor is switched because we want the initiator of the trustline to be _debtor.
                 // So every Given / Received has to be switched.
@@ -1125,7 +1148,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
                     _creditlineReceived,
                     _creditlineGiven,
                     _interestRateReceived,
-                    _interestRateGiven
+                    _interestRateGiven,
+                    _isFrozen
                 );
                 _applyOnboardingRules(_creditor, _debtor);
 
@@ -1138,7 +1162,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
                     _creditlineGiven,
                     _creditlineReceived,
                     _interestRateGiven,
-                    _interestRateReceived
+                    _interestRateReceived,
+                    _isFrozen
                 );
 
                 return true;
@@ -1151,7 +1176,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
                 _creditlineGiven,
                 _creditlineReceived,
                 _interestRateGiven,
-                _interestRateReceived
+                _interestRateReceived,
+                _isFrozen
             );
 
             return true;
@@ -1169,8 +1195,9 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
     {
         int16 interestRateGiven = defaultInterestRate;
         int16 interestRateReceived = defaultInterestRate;
+        TrustlineAgreement memory trustlineAgreement = _loadTrustlineAgreement(_creditor, _debtor);
+        bool isFrozen = trustlineAgreement.isFrozen;
         if (customInterests) {
-            TrustlineAgreement memory trustlineAgreement = _loadTrustlineAgreement(_creditor, _debtor);
             interestRateGiven = trustlineAgreement.interestRateGiven;
             interestRateReceived = trustlineAgreement.interestRateReceived;
         }
@@ -1180,7 +1207,9 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
             _creditlineGiven,
             _creditlineReceived,
             interestRateGiven,
-            interestRateReceived);
+            interestRateReceived,
+            isFrozen
+        );
     }
 
     // Actually change the trustline
@@ -1190,7 +1219,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         uint64 _creditlineGiven,
         uint64 _creditlineReceived,
         int16 _interestRateGiven,
-        int16 _interestRateReceived
+        int16 _interestRateReceived,
+        bool _isFrozen
     )
         internal
     {
@@ -1209,6 +1239,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         _trustline.agreement.creditlineReceived = _creditlineReceived;
         _trustline.agreement.interestRateGiven = _interestRateGiven;
         _trustline.agreement.interestRateReceived = _interestRateReceived;
+        _trustline.agreement.isFrozen = _isFrozen;
         _storeTrustlineBalances(_creditor, _debtor, _trustline.balances);
         _storeTrustlineAgreement(_creditor, _debtor, _trustline.agreement);
 
@@ -1218,7 +1249,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
             _creditlineGiven,
             _creditlineReceived,
             _interestRateGiven,
-            _interestRateReceived
+            _interestRateReceived,
+            _isFrozen
         );
     }
 
@@ -1248,7 +1280,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         uint64 _creditlineGiven,
         uint64 _creditlineReceived,
         int16 _interestRateGiven,
-        int16 _interestRateReceived
+        int16 _interestRateReceived,
+        bool _isFrozen
     )
         internal
     {
@@ -1260,7 +1293,9 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
                 _creditlineReceived,
                 _interestRateGiven,
                 _interestRateReceived,
-                _creditor)
+                _isFrozen,
+                _creditor
+                )
         );
 
         emit TrustlineUpdateRequest(
@@ -1269,7 +1304,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
             _creditlineGiven,
             _creditlineReceived,
             _interestRateGiven,
-            _interestRateReceived
+            _interestRateReceived,
+            _isFrozen
         );
     }
 

--- a/py-deploy/tldeploy/core.py
+++ b/py-deploy/tldeploy/core.py
@@ -71,7 +71,7 @@ def deploy_network(
     prevent_mediator_interests=False,
     exchange_address=None,
     currency_network_contract_name=None,
-    set_account_enabled=False,
+    account_management_enabled=False,
 ):
     # CurrencyNetwork is the standard contract to deploy, If we're running
     # tests or trying to export data for testing the python implementation of
@@ -97,7 +97,7 @@ def deploy_network(
             exchange_address
         ).transact({"from": web3.eth.accounts[0]})
         wait_for_successful_transaction_receipt(web3, txid)
-    if set_account_enabled is False:
+    if account_management_enabled is False:
         txid = currency_network.functions.disableAccountManagement().transact(
             {"from": web3.eth.accounts[0]}
         )

--- a/tests/test_close_trustline.py
+++ b/tests/test_close_trustline.py
@@ -47,14 +47,15 @@ def currency_network_contract_with_trustlines(chain, web3, accounts, interest_ra
             currency_network_contract.functions.setAccount(
                 a,
                 b,
-                1000000,  # creditline given
-                1000000,  # creditline received
-                interest_rate,  # interest rate given
-                interest_rate,  # interest rate received
-                0,  # fees outstanding a
-                0,  # fees outstanding b
+                1000000,
+                1000000,
+                interest_rate,
+                interest_rate,
+                False,
+                0,
+                0,
                 current_time,
-                0,  # balance
+                0,
             ).transact()
 
     currency_network_contract.functions.transfer(
@@ -86,10 +87,10 @@ def ensure_trustline_closed(contract, address1, address2):
 def test_close_trustline(currency_network_contract, accounts):
     contract = currency_network_contract
 
-    contract.functions.updateTrustline(accounts[1], 1000, 1000, 0, 0).transact(
+    contract.functions.updateTrustline(accounts[1], 1000, 1000, 0, 0, False).transact(
         {"from": accounts[0]}
     )
-    contract.functions.updateTrustline(accounts[0], 1000, 1000, 0, 0).transact(
+    contract.functions.updateTrustline(accounts[0], 1000, 1000, 0, 0, False).transact(
         {"from": accounts[1]}
     )
 
@@ -100,10 +101,10 @@ def test_close_trustline(currency_network_contract, accounts):
 def test_cannot_close_with_balance(currency_network_contract, accounts):
     contract = currency_network_contract
 
-    contract.functions.updateTrustline(accounts[1], 1000, 1000, 0, 0).transact(
+    contract.functions.updateTrustline(accounts[1], 1000, 1000, 0, 0, False).transact(
         {"from": accounts[0]}
     )
-    contract.functions.updateTrustline(accounts[0], 1000, 1000, 0, 0).transact(
+    contract.functions.updateTrustline(accounts[0], 1000, 1000, 0, 0, False).transact(
         {"from": accounts[1]}
     )
 
@@ -116,11 +117,11 @@ def test_cannot_close_with_balance(currency_network_contract, accounts):
 
 def test_cannot_reopen_closed_trustline(currency_network_contract, accounts):
     contract = currency_network_contract
-    contract.functions.updateTrustline(accounts[1], 1000, 1000, 0, 0).transact(
+    contract.functions.updateTrustline(accounts[1], 1000, 1000, 0, 0, False).transact(
         {"from": accounts[0]}
     )
     contract.functions.closeTrustline(accounts[1]).transact({"from": accounts[0]})
-    contract.functions.updateTrustline(accounts[0], 1000, 1000, 0, 0).transact(
+    contract.functions.updateTrustline(accounts[0], 1000, 1000, 0, 0, False).transact(
         {"from": accounts[1]}
     )
     ensure_trustline_closed(contract, accounts[0], accounts[1])

--- a/tests/test_close_trustline.py
+++ b/tests/test_close_trustline.py
@@ -19,7 +19,7 @@ NETWORK_SETTING = {
     "custom_interests": True,
     "prevent_mediator_interests": False,
     "currency_network_contract_name": "TestCurrencyNetwork",
-    "set_account_enabled": True,
+    "account_management_enabled": True,
     "expiration_time": EXPIRATION_TIME,
 }
 

--- a/tests/test_close_trustline.py
+++ b/tests/test_close_trustline.py
@@ -45,17 +45,17 @@ def currency_network_contract_with_trustlines(chain, web3, accounts, interest_ra
             if a is b:
                 continue
             currency_network_contract.functions.setAccount(
-                a,
-                b,
-                1000000,
-                1000000,
-                interest_rate,
-                interest_rate,
-                False,
-                0,
-                0,
-                current_time,
-                0,
+                _a=a,
+                _b=b,
+                _creditlineGiven=1000000,
+                _creditlineReceived=1000000,
+                _interestRateGiven=interest_rate,
+                _interestRateReceived=interest_rate,
+                _isFrozen=False,
+                _feesOutstandingA=0,
+                _feesOutstandingB=0,
+                _mtime=current_time,
+                _balance=0,
             ).transact()
 
     currency_network_contract.functions.transfer(

--- a/tests/test_currency_network_basics.py
+++ b/tests/test_currency_network_basics.py
@@ -24,7 +24,7 @@ NETWORK_SETTING = {
     "default_interest_rate": 0,
     "custom_interests": False,
     "currency_network_contract_name": "TestCurrencyNetwork",
-    "set_account_enabled": True,
+    "account_management_enabled": True,
     "expiration_time": EXPIRATION_TIME,
 }
 
@@ -56,7 +56,7 @@ def currency_network_contract_custom_interest(web3):
         default_interest_rate=0,
         custom_interests=True,
         prevent_mediator_interests=False,
-        set_account_enabled=True,
+        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
 
@@ -819,7 +819,7 @@ def test_overflow_max_transfer(currency_network_contract, accounts):
 
 def test_disabled_set_account(currency_network_contract, accounts):
     """
-    Tests that we cannot set an account when set_account_enabled is False.
+    Tests that we cannot set an account when account_management_enabled is False.
     """
     network = currency_network_contract
 
@@ -837,7 +837,7 @@ def test_disabled_set_account(currency_network_contract, accounts):
 
 def test_enabled_set_account(currency_network_contract, accounts):
     """
-    Tests that we can set an account when set_account_enabled is True.
+    Tests that we can set an account when account_management_enabled is True.
     """
     network = currency_network_contract
 

--- a/tests/test_currency_network_basics.py
+++ b/tests/test_currency_network_basics.py
@@ -39,7 +39,7 @@ def currency_network_contract_with_trustlines(web3, accounts):
     contract = deploy_network(web3, **NETWORK_SETTING)
     for (A, B, clAB, clBA) in trustlines:
         contract.functions.setAccount(
-            accounts[A], accounts[B], clAB, clBA, 0, 0, 0, 0, 0, 0
+            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0, 0, 0
         ).transact()
     return contract
 
@@ -97,7 +97,7 @@ def test_friends(currency_network_contract_with_trustlines, accounts):
 def test_set_get_Account(currency_network_contract_custom_interest, accounts):
     contract = currency_network_contract_custom_interest
     contract.functions.setAccount(
-        accounts[0], accounts[1], 10, 20, 2, 3, 100, 200, 0, 4
+        accounts[0], accounts[1], 10, 20, 2, 3, False, 100, 200, 0, 4
     ).transact()
     assert contract.functions.getAccount(accounts[0], accounts[1]).call() == [
         10,
@@ -122,7 +122,7 @@ def test_set_get_Account(currency_network_contract_custom_interest, accounts):
         -4,
     ]
     contract.functions.setAccount(
-        accounts[1], accounts[0], 10, 20, 2, 3, 100, 200, 0, 4
+        accounts[1], accounts[0], 10, 20, 2, 3, False, 100, 200, 0, 4
     ).transact()
     assert contract.functions.getAccount(accounts[1], accounts[0]).call() == [
         10,
@@ -159,7 +159,7 @@ def test_creditlines(currency_network_contract_with_trustlines, accounts):
 def test_set_get_Account_default_interests(currency_network_contract, accounts):
     contract = currency_network_contract
     contract.functions.setAccountDefaultInterests(
-        accounts[0], accounts[1], 10, 20, 100, 200, 0, 4
+        accounts[0], accounts[1], 10, 20, False, 100, 200, 0, 4
     ).transact()
     # setAccount(address, address, creditLimit, creditLimit, interest, interest, feeOut, feeOut, mtime, balance)
     assert contract.functions.getAccount(accounts[0], accounts[1]).call() == [
@@ -185,7 +185,7 @@ def test_set_get_Account_default_interests(currency_network_contract, accounts):
         -4,
     ]
     contract.functions.setAccountDefaultInterests(
-        accounts[1], accounts[0], 10, 20, 100, 200, 0, 4
+        accounts[1], accounts[0], 10, 20, False, 100, 200, 0, 4
     ).transact()
     assert contract.functions.getAccount(accounts[1], accounts[0]).call() == [
         10,
@@ -214,7 +214,7 @@ def test_set_get_Account_default_interests(currency_network_contract, accounts):
 def test_balance(currency_network_contract, accounts):
     contract = currency_network_contract
     contract.functions.setAccount(
-        accounts[0], accounts[1], 10, 20, 0, 0, 100, 200, 0, 4
+        accounts[0], accounts[1], 10, 20, 0, 0, False, 100, 200, 0, 4
     ).transact()
     assert contract.functions.balance(accounts[0], accounts[1]).call() == 4
     assert contract.functions.balance(accounts[1], accounts[0]).call() == -4
@@ -465,7 +465,7 @@ def test_update_without_accept_trustline_interests(
     contract = currency_network_contract_custom_interest
 
     A, B, *rest = accounts
-    contract.functions.updateTrustline(B, 50, 100, 1, 0).transact({"from": A})
+    contract.functions.updateTrustline(B, 50, 100, 1, 0, False).transact({"from": A})
 
     assert contract.functions.interestRate(A, B).call() == 0
     assert contract.functions.interestRate(B, A).call() == 0
@@ -487,8 +487,8 @@ def test_update_with_accept_trustline_interests(
     contract = currency_network_contract_custom_interest
 
     A, B, *rest = accounts
-    contract.functions.updateTrustline(B, 50, 100, 1, 0).transact({"from": A})
-    contract.functions.updateTrustline(A, 100, 50, 0, 1).transact({"from": B})
+    contract.functions.updateTrustline(B, 50, 100, 1, 0, False).transact({"from": A})
+    contract.functions.updateTrustline(A, 100, 50, 0, 1, False).transact({"from": B})
 
     assert contract.functions.interestRate(A, B).call() == 1
     assert contract.functions.interestRate(B, A).call() == 0
@@ -512,8 +512,8 @@ def test_update_with_accept_different_trustline_interests(
     contract = currency_network_contract_custom_interest
 
     A, B, *rest = accounts
-    contract.functions.updateTrustline(B, 50, 100, 1, 0).transact({"from": A})
-    contract.functions.updateTrustline(A, 100, 50, 0, 2).transact({"from": B})
+    contract.functions.updateTrustline(B, 50, 100, 1, 0, False).transact({"from": A})
+    contract.functions.updateTrustline(A, 100, 50, 0, 2, False).transact({"from": B})
     assert contract.functions.interestRate(A, B).call() == 0
     assert contract.functions.interestRate(B, A).call() == 0
     assert (
@@ -528,9 +528,9 @@ def test_update_with_accept_2nd_trustline_interests(
     contract = currency_network_contract_custom_interest
 
     A, B, *rest = accounts
-    contract.functions.updateTrustline(B, 50, 100, 2, 0).transact({"from": A})
-    contract.functions.updateTrustline(B, 50, 100, 1, 0).transact({"from": A})
-    contract.functions.updateTrustline(A, 100, 50, 0, 1).transact({"from": B})
+    contract.functions.updateTrustline(B, 50, 100, 2, 0, False).transact({"from": A})
+    contract.functions.updateTrustline(B, 50, 100, 1, 0, False).transact({"from": A})
+    contract.functions.updateTrustline(A, 100, 50, 0, 1, False).transact({"from": B})
     assert contract.functions.interestRate(A, B).call() == 1
     assert contract.functions.interestRate(B, A).call() == 0
     assert (
@@ -553,9 +553,9 @@ def test_cannot_accept_old_trustline_interests(
     contract = currency_network_contract_custom_interest
 
     A, B, *rest = accounts
-    contract.functions.updateTrustline(B, 50, 100, 2, 0).transact({"from": A})
-    contract.functions.updateTrustline(B, 50, 100, 1, 0).transact({"from": A})
-    contract.functions.updateTrustline(A, 100, 50, 0, 2).transact({"from": B})
+    contract.functions.updateTrustline(B, 50, 100, 2, 0, False).transact({"from": A})
+    contract.functions.updateTrustline(B, 50, 100, 1, 0, False).transact({"from": A})
+    contract.functions.updateTrustline(A, 100, 50, 0, 2, False).transact({"from": B})
     assert contract.functions.interestRate(A, B).call() == 0
     assert contract.functions.interestRate(B, A).call() == 0
     assert (
@@ -570,16 +570,16 @@ def test_cannot_accept_trustline_request_after_reduce(
     contract = currency_network_contract_custom_interest
 
     A, B, *rest = accounts
-    contract.functions.updateTrustline(B, 50, 100, 0, 0).transact(
+    contract.functions.updateTrustline(B, 50, 100, 0, 0, False).transact(
         {"from": A}
     )  # Propose trustline
-    contract.functions.updateTrustline(A, 100, 50, 0, 0).transact(
+    contract.functions.updateTrustline(A, 100, 50, 0, 0, False).transact(
         {"from": B}
     )  # Accept trustline
-    contract.functions.updateTrustline(B, 10, 20, 0, 0).transact(
+    contract.functions.updateTrustline(B, 10, 20, 0, 0, False).transact(
         {"from": A}
     )  # Lower trustline
-    contract.functions.updateTrustline(A, 100, 50, 0, 0).transact(
+    contract.functions.updateTrustline(A, 100, 50, 0, 0, False).transact(
         {"from": B}
     )  # Try to accept old trustline
     assert contract.functions.creditline(A, B).call() == 10
@@ -594,7 +594,9 @@ def test_update_trustline_with_custom_while_forbidden(
 
     A, B, *rest = accounts
     with pytest.raises(eth_tester.exceptions.TransactionFailed):
-        contract.functions.updateTrustline(B, 50, 100, 2, 1).transact({"from": A})
+        contract.functions.updateTrustline(B, 50, 100, 2, 1, False).transact(
+            {"from": A}
+        )
 
 
 def test_update_trustline_with_custom_while_forbidden_lowering_interests(
@@ -607,10 +609,14 @@ def test_update_trustline_with_custom_while_forbidden_lowering_interests(
     ).transact()
 
     A, B, *rest = accounts
-    contract.functions.setAccountDefaultInterests(A, B, 200, 200, 0, 0, 0, 0).transact()
+    contract.functions.setAccountDefaultInterests(
+        A, B, 200, 200, False, 0, 0, 0, 0
+    ).transact()
 
     with pytest.raises(eth_tester.exceptions.TransactionFailed):
-        contract.functions.updateTrustline(B, 50, 100, 1, 1).transact({"from": A})
+        contract.functions.updateTrustline(B, 50, 100, 1, 1, False).transact(
+            {"from": A}
+        )
 
 
 def test_update_trustline_lowering_interest_given(currency_network_contract, accounts):
@@ -621,8 +627,8 @@ def test_update_trustline_lowering_interest_given(currency_network_contract, acc
     ).transact()
 
     A, B, *rest = accounts
-    contract.functions.updateTrustline(B, 100, 100, 0, 2).transact({"from": A})
-    contract.functions.updateTrustline(A, 100, 100, 1, 0).transact({"from": B})
+    contract.functions.updateTrustline(B, 100, 100, 0, 2, False).transact({"from": A})
+    contract.functions.updateTrustline(A, 100, 100, 1, 0, False).transact({"from": B})
 
     assert contract.functions.creditline(A, B).call() == 100
     assert contract.functions.interestRate(B, A).call() == 1
@@ -638,8 +644,8 @@ def test_update_trustline_lowering_interest_received(
     ).transact()
 
     A, B, *rest = accounts
-    contract.functions.updateTrustline(B, 100, 100, 2, 0).transact({"from": A})
-    contract.functions.updateTrustline(A, 100, 100, 0, 1).transact({"from": B})
+    contract.functions.updateTrustline(B, 100, 100, 2, 0, False).transact({"from": A})
+    contract.functions.updateTrustline(A, 100, 100, 0, 1, False).transact({"from": B})
 
     assert (
         contract.events.TrustlineUpdate.createFilter(fromBlock=0).get_all_entries()
@@ -665,6 +671,7 @@ def test_setting_trustline_with_negative_interests_with_custom_interests(
             2000000000,
             -1000,
             -1000,
+            False,
             0,
             0,
             1442509455,
@@ -674,7 +681,9 @@ def test_setting_trustline_with_negative_interests_with_custom_interests(
 
     A, B, *rest = accounts
     with pytest.raises(eth_tester.exceptions.TransactionFailed):
-        contract.functions.updateTrustline(B, 100, 100, -2, 0).transact({"from": A})
+        contract.functions.updateTrustline(B, 100, 100, -2, 0, False).transact(
+            {"from": A}
+        )
 
 
 def test_spendable(currency_network_contract_with_trustlines, accounts):
@@ -753,7 +762,7 @@ def test_update_trustline_add_users(currency_network_contract, accounts):
 def test_update_set_account_add_users(currency_network_contract, accounts):
     contract = currency_network_contract
     A, B, *rest = accounts
-    contract.functions.setAccount(A, B, 50, 100, 0, 0, 0, 0, 0, 0).transact()
+    contract.functions.setAccount(A, B, 50, 100, 0, 0, False, 0, 0, 0, 0).transact()
     assert len(contract.functions.getUsers().call()) == 2
 
 
@@ -817,8 +826,8 @@ def test_disabled_set_account(currency_network_contract, accounts):
     network.functions.disableAccountManagement().transact()
     assert network.functions.accountManagementEnabled().call() is False
 
-    account = (accounts[0], accounts[1], 100, 100, 0, 0, 0, 0, 0, 0)
-    account_no_interest = (accounts[0], accounts[1], 100, 100, 0, 0, 0, 0)
+    account = (accounts[0], accounts[1], 100, 100, 0, 0, False, 0, 0, 0, 0)
+    account_no_interest = (accounts[0], accounts[1], 100, 100, False, 0, 0, 0, 0)
 
     with pytest.raises(eth_tester.exceptions.TransactionFailed):
         network.functions.setAccount(*account).transact()
@@ -834,8 +843,8 @@ def test_enabled_set_account(currency_network_contract, accounts):
 
     assert network.functions.accountManagementEnabled().call() is True
 
-    account = (accounts[0], accounts[1], 100, 100, 0, 0, 0, 0, 0, 0)
-    account_no_interest = (accounts[0], accounts[1], 200, 200, 0, 0, 0, 0)
+    account = (accounts[0], accounts[1], 100, 100, 0, 0, False, 0, 0, 0, 0)
+    account_no_interest = (accounts[0], accounts[1], 200, 200, False, 0, 0, 0, 0)
 
     network.functions.setAccount(*account).transact()
     assert network.functions.balanceOf(accounts[0]).call() == 100

--- a/tests/test_currency_network_fees.py
+++ b/tests/test_currency_network_fees.py
@@ -26,7 +26,7 @@ def currency_network_contract_with_trustlines(web3, accounts):
         symbol="T",
         decimals=6,
         fee_divisor=100,
-        set_account_enabled=True,
+        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
     for (A, B, clAB, clBA) in trustlines:

--- a/tests/test_currency_network_fees.py
+++ b/tests/test_currency_network_fees.py
@@ -31,7 +31,7 @@ def currency_network_contract_with_trustlines(web3, accounts):
     )
     for (A, B, clAB, clBA) in trustlines:
         contract.functions.setAccount(
-            accounts[A], accounts[B], clAB, clBA, 0, 0, 0, 0, 0, 0
+            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0, 0, 0
         ).transact()
     return contract
 

--- a/tests/test_currency_network_freezing.py
+++ b/tests/test_currency_network_freezing.py
@@ -14,7 +14,7 @@ NETWORK_SETTING = {
     "default_interest_rate": 0,
     "custom_interests": False,
     "currency_network_contract_name": "TestCurrencyNetwork",
-    "set_account_enabled": True,
+    "account_management_enabled": True,
     "expiration_time": EXPIRATION_TIME,
 }
 

--- a/tests/test_currency_network_freezing.py
+++ b/tests/test_currency_network_freezing.py
@@ -39,7 +39,7 @@ def currency_network_contract_with_trustlines(web3, accounts, chain):
     contract = deploy_network(web3, **NETWORK_SETTING)
     for (A, B, clAB, clBA) in trustlines:
         contract.functions.setAccount(
-            accounts[A], accounts[B], clAB, clBA, 0, 0, 0, 0, 0, 0
+            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0, 0, 0
         ).transact()
 
     return contract
@@ -65,9 +65,9 @@ def frozen_functions_and_args(accounts):
         ["transfer", (accounts[1], 1, 2, [accounts[1]], b"")],
         ["transferReceiverPays", (accounts[1], 1, 2, [accounts[1]], b"")],
         ["transferFrom", (accounts[0], accounts[1], 1, 2, [accounts[1]], b"")],
-        ["updateTrustline", (accounts[1], 101, 101, 101, 101)],
+        ["updateTrustline", (accounts[1], 101, 101, 101, 101, False)],
         ["updateCreditlimits", (accounts[1], 101, 101)],
-        ["updateTrustlineDefaultInterests", (accounts[1], 101, 101)],
+        ["updateTrustlineDefaultInterests", (accounts[1], 101, 101, False)],
         ["closeTrustline", [accounts[1]]],
         [
             "closeTrustlineByTriangularTransfer",

--- a/tests/test_currency_network_interests.py
+++ b/tests/test_currency_network_interests.py
@@ -30,7 +30,7 @@ def currency_network_contract_no_interests(web3):
         custom_interests=False,
         prevent_mediator_interests=False,
         currency_network_contract_name="TestCurrencyNetwork",
-        set_account_enabled=True,
+        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
 
@@ -47,7 +47,7 @@ def currency_network_contract_default_interests(web3):
         custom_interests=False,
         prevent_mediator_interests=False,
         currency_network_contract_name="TestCurrencyNetwork",
-        set_account_enabled=True,
+        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
 
@@ -64,7 +64,7 @@ def currency_network_contract_negative_interests(web3):
         custom_interests=False,
         prevent_mediator_interests=False,
         currency_network_contract_name="TestCurrencyNetwork",
-        set_account_enabled=True,
+        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
 
@@ -81,7 +81,7 @@ def currency_network_contract_custom_interests_safe_ripple(web3):
         custom_interests=True,
         prevent_mediator_interests=True,
         currency_network_contract_name="TestCurrencyNetwork",
-        set_account_enabled=True,
+        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
 

--- a/tests/test_currency_network_interests.py
+++ b/tests/test_currency_network_interests.py
@@ -106,6 +106,7 @@ def test_interests_positive_balance(
         2000000000,
         100,
         100,
+        False,
         0,
         0,
         current_time,
@@ -142,6 +143,7 @@ def test_interests_high_value(
         2000000000,
         2000,
         2000,
+        False,
         0,
         0,
         current_time,
@@ -174,6 +176,7 @@ def test_interests_negative_balance(
         2000000000,
         100,
         100,
+        False,
         0,
         0,
         current_time,
@@ -207,6 +210,7 @@ def test_no_interests(
         2000000000,
         0,
         0,
+        False,
         0,
         0,
         current_time,
@@ -234,7 +238,7 @@ def test_custom_interests(
 
     contract = currency_network_contract_custom_interests_safe_ripple
     contract.functions.setAccount(
-        accounts[0], accounts[1], 0, 2000000000, 0, 1234, 0, 0, 0, 0
+        accounts[0], accounts[1], 0, 2000000000, 0, 1234, False, 0, 0, 0, 0
     ).transact()
     current_time = int(time.time())
     chain.time_travel(current_time + SECONDS_PER_YEAR)
@@ -264,7 +268,17 @@ def test_custom_interests_postive_balance(
     current_time = int(time.time())
     chain.time_travel(current_time + 10)
     contract.functions.setAccount(
-        accounts[0], accounts[1], 0, 2000000000, 1234, 0, 0, 0, current_time, 100000000
+        accounts[0],
+        accounts[1],
+        0,
+        2000000000,
+        1234,
+        0,
+        False,
+        0,
+        0,
+        current_time,
+        100000000,
     ).transact()
 
     chain.time_travel(current_time + SECONDS_PER_YEAR)
@@ -301,7 +315,7 @@ def test_safe_interest_allows_direct_transactions(
 
     contract = currency_network_contract_custom_interests_safe_ripple
     contract.functions.setAccount(
-        accounts[0], accounts[1], 1000000, 2000000, 100, 200, 0, 0, 0, 0
+        accounts[0], accounts[1], 1000000, 2000000, 100, 200, False, 0, 0, 0, 0
     ).transact()
     # setAccount(address, address, creditLimit, creditLimit, interest, interest, feeOut, feeOut, mtime, balance)
 
@@ -322,10 +336,30 @@ def test_safe_interest_allows_transactions_mediated(
     current_time = int(time.time())
     chain.time_travel(current_time + 10)
     contract.functions.setAccount(
-        accounts[0], accounts[1], 1000000, 2000000, 100, 200, 0, 0, current_time, 0
+        accounts[0],
+        accounts[1],
+        1000000,
+        2000000,
+        100,
+        200,
+        False,
+        0,
+        0,
+        current_time,
+        0,
     ).transact()
     contract.functions.setAccount(
-        accounts[1], accounts[2], 1000000, 2000000, 100, 200, 0, 0, current_time, 0
+        accounts[1],
+        accounts[2],
+        1000000,
+        2000000,
+        100,
+        200,
+        False,
+        0,
+        0,
+        current_time,
+        0,
     ).transact()
     # setAccount(address, address, creditLimit, creditLimit, interest, interest, feeOut, feeOut, mtime, balance)
 
@@ -347,10 +381,30 @@ def test_safe_interest_disallows_transactions_mediated_if_interests_increase(
     current_time = int(time.time())
     chain.time_travel(current_time + 10)
     contract.functions.setAccount(
-        accounts[0], accounts[1], 1000000, 2000000, 200, 100, 0, 0, current_time, 0
+        accounts[0],
+        accounts[1],
+        1000000,
+        2000000,
+        200,
+        100,
+        False,
+        0,
+        0,
+        current_time,
+        0,
     ).transact()
     contract.functions.setAccount(
-        accounts[1], accounts[2], 1000000, 2000000, 100, 200, 0, 0, current_time, 0
+        accounts[1],
+        accounts[2],
+        1000000,
+        2000000,
+        100,
+        200,
+        False,
+        0,
+        0,
+        current_time,
+        0,
     ).transact()
 
     with pytest.raises(eth_tester.exceptions.TransactionFailed):
@@ -371,10 +425,30 @@ def test_safe_interest_allows_transactions_mediated_solves_imbalance(
     current_time = int(time.time())
     chain.time_travel(current_time + 10)
     contract.functions.setAccount(
-        accounts[0], accounts[1], 1000000, 2000000, 200, 100, 0, 0, current_time, 100
+        accounts[0],
+        accounts[1],
+        1000000,
+        2000000,
+        200,
+        100,
+        False,
+        0,
+        0,
+        current_time,
+        100,
     ).transact()
     contract.functions.setAccount(
-        accounts[1], accounts[2], 1000000, 2000000, 100, 200, 0, 0, current_time, 100
+        accounts[1],
+        accounts[2],
+        1000000,
+        2000000,
+        100,
+        200,
+        False,
+        0,
+        0,
+        current_time,
+        100,
     ).transact()
 
     getattr(contract.functions, transfer_function_name)(
@@ -394,10 +468,30 @@ def test_safe_interest_disallows_transactions_mediated_solves_imbalance_but_over
     current_time = int(time.time())
     chain.time_travel(current_time + 10)
     contract.functions.setAccount(
-        accounts[0], accounts[1], 1000000, 2000000, 200, 100, 0, 0, current_time, 100
+        accounts[0],
+        accounts[1],
+        1000000,
+        2000000,
+        200,
+        100,
+        False,
+        0,
+        0,
+        current_time,
+        100,
     ).transact()
     contract.functions.setAccount(
-        accounts[1], accounts[2], 1000000, 2000000, 100, 200, 0, 0, current_time, 100
+        accounts[1],
+        accounts[2],
+        1000000,
+        2000000,
+        100,
+        200,
+        False,
+        0,
+        0,
+        current_time,
+        100,
     ).transact()
 
     with pytest.raises(eth_tester.exceptions.TransactionFailed):
@@ -424,6 +518,7 @@ def test_negative_interests_default_positive_balance(
         2000000000,
         -100,
         -100,
+        False,
         0,
         0,
         current_time,
@@ -459,6 +554,7 @@ def test_negative_interests_default_negative_balance(
         2000000000,
         -100,
         -100,
+        False,
         0,
         0,
         current_time,
@@ -494,6 +590,7 @@ def test_interests_overflow(
         2 ** CREDITLINE_WIDTH - 1,
         2 ** (INTEREST_WIDTH - 1) - 1,
         2 ** (INTEREST_WIDTH - 1) - 1,
+        False,
         0,
         0,
         current_time,
@@ -524,6 +621,7 @@ def test_interests_underflow(
         2 ** CREDITLINE_WIDTH - 1,
         2 ** (INTEREST_WIDTH - 1) - 1,
         2 ** (INTEREST_WIDTH - 1) - 1,
+        False,
         0,
         0,
         current_time,
@@ -553,12 +651,12 @@ def test_interests_over_change_in_trustline(
     current_time = int(time.time())
     chain.time_travel(current_time + 10)
 
-    contract.functions.updateTrustline(accounts[0], 100000, 100000, 0, 0).transact(
-        {"from": accounts[1]}
-    )
-    contract.functions.updateTrustline(accounts[1], 100000, 100000, 0, 0).transact(
-        {"from": accounts[0]}
-    )
+    contract.functions.updateTrustline(
+        accounts[0], 100000, 100000, 0, 0, False
+    ).transact({"from": accounts[1]})
+    contract.functions.updateTrustline(
+        accounts[1], 100000, 100000, 0, 0, False
+    ).transact({"from": accounts[0]})
     contract.functions.transfer(
         accounts[1], 10000, 0, [accounts[1]], EXTRA_DATA
     ).transact({"from": accounts[0]})
@@ -566,10 +664,10 @@ def test_interests_over_change_in_trustline(
     chain.time_travel(current_time + SECONDS_PER_YEAR)
 
     contract.functions.updateTrustline(
-        accounts[0], 100000, 100000, 1000, 1000
+        accounts[0], 100000, 100000, 1000, 1000, False
     ).transact({"from": accounts[1]})
     contract.functions.updateTrustline(
-        accounts[1], 100000, 100000, 1000, 1000
+        accounts[1], 100000, 100000, 1000, 1000, False
     ).transact({"from": accounts[0]})
 
     contract.functions.transfer(accounts[1], 1, 0, [accounts[1]], EXTRA_DATA).transact(
@@ -586,12 +684,12 @@ def test_payback_interests_even_over_creditline(
     current_time = int(time.time())
     chain.time_travel(current_time + 10)
 
-    contract.functions.updateTrustline(accounts[0], 10000, 10000, 200, 200).transact(
-        {"from": accounts[1]}
-    )
-    contract.functions.updateTrustline(accounts[1], 10000, 10000, 200, 200).transact(
-        {"from": accounts[0]}
-    )
+    contract.functions.updateTrustline(
+        accounts[0], 10000, 10000, 200, 200, False
+    ).transact({"from": accounts[1]})
+    contract.functions.updateTrustline(
+        accounts[1], 10000, 10000, 200, 200, False
+    ).transact({"from": accounts[0]})
     contract.functions.transfer(
         accounts[0], 10000, 0, [accounts[0]], EXTRA_DATA
     ).transact({"from": accounts[1]})
@@ -614,12 +712,12 @@ def test_interests_over_creditline_is_usable(
     current_time = int(time.time())
     chain.time_travel(current_time + 10)
 
-    contract.functions.updateTrustline(accounts[0], 10000, 10000, 200, 200).transact(
-        {"from": accounts[1]}
-    )
-    contract.functions.updateTrustline(accounts[1], 10000, 10000, 200, 200).transact(
-        {"from": accounts[0]}
-    )
+    contract.functions.updateTrustline(
+        accounts[0], 10000, 10000, 200, 200, False
+    ).transact({"from": accounts[1]})
+    contract.functions.updateTrustline(
+        accounts[1], 10000, 10000, 200, 200, False
+    ).transact({"from": accounts[0]})
     contract.functions.transfer(
         accounts[0], 10000, 0, [accounts[0]], EXTRA_DATA
     ).transact({"from": accounts[1]})
@@ -643,12 +741,12 @@ def test_correct_balance_update_event_on_interest_rate_change(
     chain.time_travel(current_time + 10)
 
     # Set trustline
-    contract.functions.updateTrustline(accounts[0], 10000, 10000, 100, 100).transact(
-        {"from": accounts[1]}
-    )
-    contract.functions.updateTrustline(accounts[1], 10000, 10000, 100, 100).transact(
-        {"from": accounts[0]}
-    )
+    contract.functions.updateTrustline(
+        accounts[0], 10000, 10000, 100, 100, False
+    ).transact({"from": accounts[1]})
+    contract.functions.updateTrustline(
+        accounts[1], 10000, 10000, 100, 100, False
+    ).transact({"from": accounts[0]})
     contract.functions.transfer(
         accounts[0], 10000, 0, [accounts[0]], EXTRA_DATA
     ).transact({"from": accounts[1]})
@@ -657,12 +755,12 @@ def test_correct_balance_update_event_on_interest_rate_change(
     chain.time_travel(current_time + SECONDS_PER_YEAR)
 
     # Update trustline
-    contract.functions.updateTrustline(accounts[0], 11000, 11000, 200, 200).transact(
-        {"from": accounts[1]}
-    )
-    contract.functions.updateTrustline(accounts[1], 11000, 11000, 200, 200).transact(
-        {"from": accounts[0]}
-    )
+    contract.functions.updateTrustline(
+        accounts[0], 11000, 11000, 200, 200, False
+    ).transact({"from": accounts[1]})
+    contract.functions.updateTrustline(
+        accounts[1], 11000, 11000, 200, 200, False
+    ).transact({"from": accounts[0]})
 
     # Check event
     events = contract.events.BalanceUpdate.createFilter(fromBlock=0).get_all_entries()

--- a/tests/test_currency_network_onbaording.py
+++ b/tests/test_currency_network_onbaording.py
@@ -25,8 +25,12 @@ def currency_network_contract(web3):
 
 
 def open_trustline(network, a, b):
-    network.functions.updateTrustlineDefaultInterests(b, 1, 1).transact({"from": a})
-    network.functions.updateTrustlineDefaultInterests(a, 1, 1).transact({"from": b})
+    network.functions.updateTrustlineDefaultInterests(b, 1, 1, False).transact(
+        {"from": a}
+    )
+    network.functions.updateTrustlineDefaultInterests(a, 1, 1, False).transact(
+        {"from": b}
+    )
 
 
 def test_no_onboarder(currency_network_contract, accounts):
@@ -80,7 +84,7 @@ def test_cannot_change_onbaorder(currency_network_contract, accounts):
 
 def test_set_account_onboards(currency_network_contract, accounts):
     currency_network_contract.functions.setAccountDefaultInterests(
-        accounts[1], accounts[2], 1, 1, 1, 1, 1, 1
+        accounts[1], accounts[2], 1, 1, False, 1, 1, 1, 1
     ).transact()
 
     owner = accounts[0]

--- a/tests/test_currency_network_onbaording.py
+++ b/tests/test_currency_network_onbaording.py
@@ -11,7 +11,7 @@ NETWORK_SETTING = {
     "default_interest_rate": 0,
     "custom_interests": False,
     "currency_network_contract_name": "TestCurrencyNetwork",
-    "set_account_enabled": True,
+    "account_management_enabled": True,
     "expiration_time": EXPIRATION_TIME,
 }
 

--- a/tests/test_currency_network_receiver_pays.py
+++ b/tests/test_currency_network_receiver_pays.py
@@ -29,7 +29,7 @@ def currency_network_contract_with_trustlines(web3, accounts):
     )
     for (A, B, clAB, clBA) in trustlines:
         contract.functions.setAccount(
-            accounts[A], accounts[B], clAB, clBA, 0, 0, 0, 0, 0, 0
+            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0, 0, 0
         ).transact()
     return contract
 
@@ -48,23 +48,23 @@ def currency_network_contract_with_high_trustlines(web3, accounts):
     )
     creditline = 1000000
     contract.functions.setAccount(
-        accounts[0], accounts[1], creditline, creditline, 0, 0, 0, 0, 0, 0
+        accounts[0], accounts[1], creditline, creditline, 0, 0, False, 0, 0, 0, 0
     ).transact()
     contract.functions.setAccount(
-        accounts[1], accounts[2], creditline, creditline, 0, 0, 0, 0, 0, 0
+        accounts[1], accounts[2], creditline, creditline, 0, 0, False, 0, 0, 0, 0
     ).transact()
     contract.functions.setAccount(
-        accounts[2], accounts[3], creditline, creditline, 0, 0, 0, 0, 0, 0
+        accounts[2], accounts[3], creditline, creditline, 0, 0, False, 0, 0, 0, 0
     ).transact()
 
     contract.functions.setAccount(
-        accounts[0], accounts[2], creditline, creditline, 0, 0, 0, 0, 0, 0
+        accounts[0], accounts[2], creditline, creditline, 0, 0, False, 0, 0, 0, 0
     ).transact()
     contract.functions.setAccount(
-        accounts[2], accounts[4], creditline, creditline, 0, 0, 0, 0, 0, 0
+        accounts[2], accounts[4], creditline, creditline, 0, 0, False, 0, 0, 0, 0
     ).transact()
     contract.functions.setAccount(
-        accounts[4], accounts[3], creditline, creditline, 0, 0, 0, 0, 0, 0
+        accounts[4], accounts[3], creditline, creditline, 0, 0, False, 0, 0, 0, 0
     ).transact()
 
     return contract

--- a/tests/test_currency_network_receiver_pays.py
+++ b/tests/test_currency_network_receiver_pays.py
@@ -24,7 +24,7 @@ def currency_network_contract_with_trustlines(web3, accounts):
         decimals=6,
         fee_divisor=100,
         currency_network_contract_name="TestCurrencyNetwork",
-        set_account_enabled=True,
+        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
     for (A, B, clAB, clBA) in trustlines:
@@ -43,7 +43,7 @@ def currency_network_contract_with_high_trustlines(web3, accounts):
         decimals=6,
         fee_divisor=100,
         currency_network_contract_name="TestCurrencyNetwork",
-        set_account_enabled=True,
+        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
     creditline = 1000000

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -44,7 +44,7 @@ def test_deploy_network(web3):
         default_interest_rate=100,
         custom_interests=False,
         prevent_mediator_interests=False,
-        set_account_enabled=True,
+        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
 

--- a/tests/test_exchange.py
+++ b/tests/test_exchange.py
@@ -52,7 +52,7 @@ def currency_network_contract_with_trustlines(web3, exchange_contract, accounts)
     )
     for (A, B, clAB, clBA) in trustlines:
         contract.functions.setAccount(
-            accounts[A], accounts[B], clAB, clBA, 0, 0, 0, 0, 0, 0
+            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0, 0, 0
         ).transact()
     contract.functions.addAuthorizedAddress(exchange_contract.address).transact()
     return contract

--- a/tests/test_exchange.py
+++ b/tests/test_exchange.py
@@ -47,7 +47,7 @@ def currency_network_contract_with_trustlines(web3, exchange_contract, accounts)
         decimals=6,
         fee_divisor=0,
         currency_network_contract_name="TestCurrencyNetwork",
-        set_account_enabled=True,
+        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
     for (A, B, clAB, clBA) in trustlines:

--- a/tests/test_gas_costs.py
+++ b/tests/test_gas_costs.py
@@ -51,7 +51,7 @@ def currency_network_contract(web3):
         decimals=2,
         fee_divisor=100,
         currency_network_contract_name="TestCurrencyNetwork",
-        set_account_enabled=True,
+        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
 
@@ -65,7 +65,7 @@ def currency_network_contract_with_trustlines(web3, accounts):
         decimals=2,
         fee_divisor=100,
         currency_network_contract_name="TestCurrencyNetwork",
-        set_account_enabled=True,
+        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
     for (A, B, clAB, clBA) in trustlines:

--- a/tests/test_gas_costs.py
+++ b/tests/test_gas_costs.py
@@ -70,7 +70,7 @@ def currency_network_contract_with_trustlines(web3, accounts):
     )
     for (A, B, clAB, clBA) in trustlines:
         contract.functions.setAccount(
-            accounts[A], accounts[B], clAB, clBA, 0, 0, 0, 0, 1, 1
+            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0, 1, 1
         ).transact()
     return contract
 
@@ -128,7 +128,7 @@ def test_cost_first_trustline_request(web3, currency_network_contract, accounts,
     A, B, *rest = accounts
     tx_hash = contract.functions.updateCreditlimits(B, 150, 150).transact({"from": A})
     gas_cost = get_gas_costs(web3, tx_hash)
-    report_gas_costs(table, "First Trustline Update Request", gas_cost, limit=77500)
+    report_gas_costs(table, "First Trustline Update Request", gas_cost, limit=78500)
 
 
 def test_cost_second_trustline_request(

--- a/tests/test_gas_costs.py
+++ b/tests/test_gas_costs.py
@@ -96,7 +96,7 @@ def test_cost_transfer_1_mediators(
         {"from": A}
     )
     gas_cost = get_gas_costs(web3, tx_hash)
-    report_gas_costs(table, "1 hop transfer", gas_cost, limit=64500)
+    report_gas_costs(table, "1 hop transfer", gas_cost, limit=65000)
 
 
 def test_cost_transfer_2_mediators(
@@ -108,7 +108,7 @@ def test_cost_transfer_2_mediators(
         {"from": A}
     )
     gas_cost = get_gas_costs(web3, tx_hash)
-    report_gas_costs(table, "2 hop transfer", gas_cost, limit=83000)
+    report_gas_costs(table, "2 hop transfer", gas_cost, limit=83500)
 
 
 def test_cost_transfer_3_mediators(
@@ -120,7 +120,7 @@ def test_cost_transfer_3_mediators(
         {"from": A}
     )
     gas_cost = get_gas_costs(web3, tx_hash)
-    report_gas_costs(table, "3 hop transfer", gas_cost, limit=101_000)
+    report_gas_costs(table, "3 hop transfer", gas_cost, limit=101_500)
 
 
 def test_cost_first_trustline_request(web3, currency_network_contract, accounts, table):


### PR DESCRIPTION
Closes: https://github.com/trustlines-protocol/contracts/issues/227

Frozen trustlines cannot be used for transfer, cannot be updated / closed.
They can still be updated by `setAccount()`, requested by Andreas.

Based on https://github.com/trustlines-protocol/contracts/pull/232, only check new commits.