### PR TITLE
Feature/currency network registry

### DIFF
--- a/contracts/CurrencyNetwork.sol
+++ b/contracts/CurrencyNetwork.sol
@@ -41,11 +41,6 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
     // Divides current value being transferred to calculate the capacity fee which equals the imbalance fee
     uint16 public capacityImbalanceFeeDivisor;
 
-    // meta data for token part
-    string public name;
-    string public symbol;
-    uint8 public decimals;
-
     // interests settings, interests are expressed in 0.01% per year
     int16 public defaultInterestRate;
     bool public customInterests;

--- a/contracts/CurrencyNetwork.sol
+++ b/contracts/CurrencyNetwork.sol
@@ -34,6 +34,12 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
     //list of all users of the system
     ItSet.AddressSet internal users;
 
+    // meta data for token part
+    // underscores internal variables, because otherwise the names clash with the functions
+    string internal _name;
+    string internal _symbol;
+    uint8 internal _decimals;
+
     bool public isInitialized;
     uint public expirationTime;
     bool public isNetworkFrozen;
@@ -124,9 +130,9 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
 
     /**
      * @notice Initialize the currency Network
-     * @param _name The name of the currency
-     * @param _symbol The symbol of the currency
-     * @param _decimals Number of decimals of the currency
+     * @param _paramName The name of the currency
+     * @param _paramSymbol The symbol of the currency
+     * @param _paramDecimals Number of decimals of the currency
      * @param _capacityImbalanceFeeDivisor Divisor of the imbalance fee. The fee is 1 / _capacityImbalanceFeeDivisor
      * @param _defaultInterestRate The default interests for every trustlines in 0.001% per year
      * @param _customInterests Flag to allow or disallow trustlines to have custom interests
@@ -135,9 +141,9 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
      * @param _expirationTime Time after which the currency network is frozen and cannot be used anymore
      */
     function init(
-        string calldata _name,
-        string calldata _symbol,
-        uint8 _decimals,
+        string calldata _paramName, // _name is blocked by the internal variable and name is the external function
+        string calldata _paramSymbol,
+        uint8 _paramDecimals,
         uint16 _capacityImbalanceFeeDivisor,
         int16 _defaultInterestRate,
         bool _customInterests,
@@ -162,9 +168,9 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
 
         require(_expirationTime > now, "Expiration time must be in the future.");
 
-        name = _name;
-        symbol = _symbol;
-        decimals = _decimals;
+        _name = _paramName;
+        _symbol = _paramSymbol;
+        _decimals = _paramDecimals;
         capacityImbalanceFeeDivisor = _capacityImbalanceFeeDivisor;
         defaultInterestRate = _defaultInterestRate;
         customInterests = _customInterests;
@@ -247,6 +253,18 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
                 _extraData
             );
         }
+    }
+
+    function name() external view returns (string memory) {
+        return _name;
+    }
+
+    function symbol() external view returns (string memory) {
+        return _symbol;
+    }
+
+    function decimals() external view returns (uint8) {
+        return _decimals;
     }
 
     /**
@@ -564,10 +582,15 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         return (
             interfaceID == this.supportsInterface.selector || // ERC165
             (   // This needs to be in sync with CurrencyNetworkInterface.sol
-                interfaceID == this.transfer.selector ^
-                this.transferFrom.selector ^
-                this.balance.selector ^
-                this.creditline.selector
+                interfaceID == (
+                    this.name.selector ^
+                    this.symbol.selector ^
+                    this.decimals.selector ^
+                    this.transfer.selector ^
+                    this.transferFrom.selector ^
+                    this.balance.selector ^
+                    this.creditline.selector
+                )
             )
         );
     }

--- a/contracts/CurrencyNetwork.sol
+++ b/contracts/CurrencyNetwork.sol
@@ -6,6 +6,7 @@ import "./tokens/Receiver_Interface.sol";
 import "./lib/Ownable.sol";
 import "./lib/Destructable.sol";
 import "./lib/Authorizable.sol";
+import "./lib/ERC165.sol";
 import "./CurrencyNetworkInterface.sol";
 
 
@@ -16,7 +17,7 @@ import "./CurrencyNetworkInterface.sol";
  * Implements functions to ripple payments in a currency network. Implements core features of ERC20
  *
  **/
-contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Destructable {
+contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Destructable, ERC165 {
 
     // Constants
     int72 constant MAX_BALANCE = 2**71 - 1;
@@ -551,6 +552,24 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
     function freezeNetwork() external {
         require(expirationTime <= now, "The currency network cannot be frozen yet.");
         isNetworkFrozen = true;
+    }
+
+    function supportsInterface(
+        bytes4 interfaceID
+    )
+        external
+        view
+        returns (bool)
+    {
+        return (
+            interfaceID == this.supportsInterface.selector || // ERC165
+            (   // This needs to be in sync with CurrencyNetworkInterface.sol
+                interfaceID == this.transfer.selector ^
+                this.transferFrom.selector ^
+                this.balance.selector ^
+                this.creditline.selector
+            )
+        );
     }
 
     /**

--- a/contracts/CurrencyNetworkInterface.sol
+++ b/contracts/CurrencyNetworkInterface.sol
@@ -1,12 +1,11 @@
 pragma solidity ^0.5.8;
 
+// ERC-165 Interface Id: 0x7ecdffaf
+interface CurrencyNetworkInterface {
 
-contract CurrencyNetworkInterface {
-
-    // meta data for token part
-    string public name;
-    string public symbol;
-    uint8 public decimals;
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+    function decimals() external view returns (uint8);
 
     function transfer(
         address _to,
@@ -29,9 +28,9 @@ contract CurrencyNetworkInterface {
         external
         returns (bool success);
 
-    function balance(address _from, address _to) public view returns (int);
+    function balance(address _from, address _to) external view returns (int);
 
-    function creditline(address _creditor, address _debtor) public view returns (uint);
+    function creditline(address _creditor, address _debtor) external view returns (uint);
 
     event Transfer(address indexed _from, address indexed _to, uint _value, bytes _extraData);
 

--- a/contracts/CurrencyNetworkInterface.sol
+++ b/contracts/CurrencyNetworkInterface.sol
@@ -3,6 +3,11 @@ pragma solidity ^0.5.8;
 
 contract CurrencyNetworkInterface {
 
+    // meta data for token part
+    string public name;
+    string public symbol;
+    uint8 public decimals;
+
     function transfer(
         address _to,
         uint64 _value,

--- a/contracts/CurrencyNetworkRegistry.sol
+++ b/contracts/CurrencyNetworkRegistry.sol
@@ -7,7 +7,7 @@ import "./lib/ERC165Query.sol";
 contract CurrencyNetworkRegistry is ERC165Query {
 
     struct CurrencyNetworkMetadata {
-        address author;
+        address registeredBy;
         string name;
         string symbol;
         uint8 decimals;
@@ -18,7 +18,7 @@ contract CurrencyNetworkRegistry is ERC165Query {
 
     event CurrencyNetworkAdded(
         address indexed _address,
-        address _author,
+        address _registeredBy,
         string _name,
         string _symbol,
         uint8 _decimals
@@ -28,7 +28,7 @@ contract CurrencyNetworkRegistry is ERC165Query {
         CurrencyNetworkInterface network;
 
         require(
-            currencyNetworks[_address].author == address(0) &&
+            currencyNetworks[_address].registeredBy == address(0) &&
             bytes(currencyNetworks[_address].name).length == 0 &&
             bytes(currencyNetworks[_address].symbol).length == 0,
             "CurrencyNetworks can only be registered once."
@@ -48,7 +48,7 @@ contract CurrencyNetworkRegistry is ERC165Query {
         );
 
         currencyNetworks[_address] = CurrencyNetworkMetadata({
-            author: msg.sender,
+            registeredBy: msg.sender,
             name: network.name(),
             symbol: network.symbol(),
             decimals: network.decimals()
@@ -58,7 +58,7 @@ contract CurrencyNetworkRegistry is ERC165Query {
 
         emit CurrencyNetworkAdded(
             _address,
-            currencyNetworks[_address].author,
+            currencyNetworks[_address].registeredBy,
             currencyNetworks[_address].name,
             currencyNetworks[_address].symbol,
             currencyNetworks[_address].decimals
@@ -79,14 +79,14 @@ contract CurrencyNetworkRegistry is ERC165Query {
         external
         view
         returns (
-            address _author,
+            address _registeredBy,
             string memory _name,
             string memory _symbol,
             uint8 _decimals
         )
     {
         return (
-            currencyNetworks[_address].author,
+            currencyNetworks[_address].registeredBy,
             currencyNetworks[_address].name,
             currencyNetworks[_address].symbol,
             currencyNetworks[_address].decimals

--- a/contracts/CurrencyNetworkRegistry.sol
+++ b/contracts/CurrencyNetworkRegistry.sol
@@ -1,0 +1,65 @@
+pragma solidity ^0.5.8;
+
+import "./CurrencyNetworkInterface.sol";
+
+contract CurrencyNetworkRegistry {
+
+    struct CurrencyNetworkMetadata {
+        address author;
+        string name;
+        string symbol;
+        uint8 decimals;
+    }
+
+    mapping (address => CurrencyNetworkMetadata) public networks;
+    address[] public registeredNetworks;
+
+    event NetworkAdded(address indexed _address, address _author, string _name, string _symbol, uint8 _decimals);
+
+    function addNetwork(address _address) external {
+        CurrencyNetworkInterface network;
+
+        require(
+            networks[_address].author == address(0) &&
+            bytes(networks[_address].name).length == 0 &&
+            bytes(networks[_address].symbol).length == 0
+            , "CurrencyNetworks can only be registered once."
+        );
+
+        network = CurrencyNetworkInterface(_address);
+
+        networks[_address] = CurrencyNetworkMetadata({
+            author: msg.sender,
+            name: network.name(),
+            symbol: network.symbol(),
+            decimals: network.decimals()
+        });
+
+        registeredNetworks.push(_address);
+
+        emit NetworkAdded(
+            _address,
+            networks[_address].author,
+            networks[_address].name,
+            networks[_address].symbol,
+            networks[_address].decimals
+        );
+    }
+
+    function getNetworkCount() external view returns (uint256 _count) {
+        return registeredNetworks.length;
+    }
+
+    function getNetworkAddress(uint256 _index) external view returns (address _network) {
+        return registeredNetworks[_index];
+    }
+
+    function getNetworkMetadata(address _address) external view returns (address _author, string memory _name, string memory _symbol, uint8 _decimals) {
+        return (
+            networks[_address].author,
+            networks[_address].name,
+            networks[_address].symbol,
+            networks[_address].decimals
+        );
+    }
+}

--- a/contracts/CurrencyNetworkRegistry.sol
+++ b/contracts/CurrencyNetworkRegistry.sol
@@ -18,7 +18,7 @@ contract CurrencyNetworkRegistry is ERC165Query {
 
     event CurrencyNetworkAdded(
         address indexed _address,
-        address _registeredBy,
+        address indexed _registeredBy,
         string _name,
         string _symbol,
         uint8 _decimals

--- a/contracts/CurrencyNetworkRegistry.sol
+++ b/contracts/CurrencyNetworkRegistry.sol
@@ -37,6 +37,7 @@ contract CurrencyNetworkRegistry is ERC165Query {
         network = CurrencyNetworkInterface(_address);
 
         require(
+            // ERC-165 check is always done implicitly
             this.doesContractImplementInterface(
                 _address,
                 network.name.selector ^

--- a/contracts/CurrencyNetworkRegistry.sol
+++ b/contracts/CurrencyNetworkRegistry.sol
@@ -39,6 +39,9 @@ contract CurrencyNetworkRegistry is ERC165Query {
         require(
             this.doesContractImplementInterface(
                 _address,
+                network.name.selector ^
+                network.symbol.selector ^
+                network.decimals.selector ^
                 network.transfer.selector ^
                 network.transferFrom.selector ^
                 network.balance.selector ^

--- a/contracts/CurrencyNetworkRegistry.sol
+++ b/contracts/CurrencyNetworkRegistry.sol
@@ -11,55 +11,55 @@ contract CurrencyNetworkRegistry {
         uint8 decimals;
     }
 
-    mapping (address => CurrencyNetworkMetadata) public networks;
-    address[] public registeredNetworks;
+    mapping (address => CurrencyNetworkMetadata) internal currencyNetworks;
+    address[] internal registeredCurrencyNetworks;
 
-    event NetworkAdded(address indexed _address, address _author, string _name, string _symbol, uint8 _decimals);
+    event CurrencyNetworkAdded(address indexed _address, address _author, string _name, string _symbol, uint8 _decimals);
 
-    function addNetwork(address _address) external {
+    function addCurrencyNetwork(address _address) external {
         CurrencyNetworkInterface network;
 
         require(
-            networks[_address].author == address(0) &&
-            bytes(networks[_address].name).length == 0 &&
-            bytes(networks[_address].symbol).length == 0
+            currencyNetworks[_address].author == address(0) &&
+            bytes(currencyNetworks[_address].name).length == 0 &&
+            bytes(currencyNetworks[_address].symbol).length == 0
             , "CurrencyNetworks can only be registered once."
         );
 
         network = CurrencyNetworkInterface(_address);
 
-        networks[_address] = CurrencyNetworkMetadata({
+        currencyNetworks[_address] = CurrencyNetworkMetadata({
             author: msg.sender,
             name: network.name(),
             symbol: network.symbol(),
             decimals: network.decimals()
         });
 
-        registeredNetworks.push(_address);
+        registeredCurrencyNetworks.push(_address);
 
-        emit NetworkAdded(
+        emit CurrencyNetworkAdded(
             _address,
-            networks[_address].author,
-            networks[_address].name,
-            networks[_address].symbol,
-            networks[_address].decimals
+            currencyNetworks[_address].author,
+            currencyNetworks[_address].name,
+            currencyNetworks[_address].symbol,
+            currencyNetworks[_address].decimals
         );
     }
 
-    function getNetworkCount() external view returns (uint256 _count) {
-        return registeredNetworks.length;
+    function getCurrencyNetworkCount() external view returns (uint256 _count) {
+        return registeredCurrencyNetworks.length;
     }
 
-    function getNetworkAddress(uint256 _index) external view returns (address _network) {
-        return registeredNetworks[_index];
+    function getCurrencyNetworkAddress(uint256 _index) external view returns (address _network) {
+        return registeredCurrencyNetworks[_index];
     }
 
-    function getNetworkMetadata(address _address) external view returns (address _author, string memory _name, string memory _symbol, uint8 _decimals) {
+    function getCurrencyNetworkMetadata(address _address) external view returns (address _author, string memory _name, string memory _symbol, uint8 _decimals) {
         return (
-            networks[_address].author,
-            networks[_address].name,
-            networks[_address].symbol,
-            networks[_address].decimals
+            currencyNetworks[_address].author,
+            currencyNetworks[_address].name,
+            currencyNetworks[_address].symbol,
+            currencyNetworks[_address].decimals
         );
     }
 }

--- a/contracts/lib/ERC165.sol
+++ b/contracts/lib/ERC165.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.5.8;
+
+interface ERC165 {
+    /// @notice Query if a contract implements an interface
+    /// @param interfaceID The interface identifier, as specified in ERC-165
+    /// @dev Interface identification is specified in ERC-165. This function
+    ///  uses less than 30,000 gas.
+    /// @return `true` if the contract implements `interfaceID` and
+    ///  `interfaceID` is not 0xffffffff, `false` otherwise
+    function supportsInterface(bytes4 interfaceID) external view returns (bool);
+}

--- a/contracts/lib/ERC165Query.sol
+++ b/contracts/lib/ERC165Query.sol
@@ -1,0 +1,47 @@
+pragma solidity ^0.5.8;
+
+contract ERC165Query {
+    bytes4 constant InvalidID = 0xffffffff;
+    bytes4 constant ERC165ID = 0x01ffc9a7;
+
+    function doesContractImplementInterface(address _contract, bytes4 _interfaceId) external view returns (bool) {
+        uint256 success;
+        uint256 result;
+
+        (success, result) = noThrowCall(_contract, ERC165ID);
+        if ((success==0)||(result==0)) {
+            return false;
+        }
+
+        (success, result) = noThrowCall(_contract, InvalidID);
+        if ((success==0)||(result!=0)) {
+            return false;
+        }
+
+        (success, result) = noThrowCall(_contract, _interfaceId);
+        if ((success==1)&&(result==1)) {
+            return true;
+        }
+        return false;
+    }
+
+    function noThrowCall(address _contract, bytes4 _interfaceId) view internal returns (uint256 success, uint256 result) {
+        bytes4 erc165ID = ERC165ID;
+
+        assembly {
+                let x := mload(0x40)               // Find empty storage location using "free memory pointer"
+                mstore(x, erc165ID)                // Place signature at beginning of empty storage
+                mstore(add(x, 0x04), _interfaceId) // Place first argument directly next to signature
+
+                success := staticcall(
+                                    30000,         // 30k gas
+                                    _contract,     // To addr
+                                    x,             // Inputs are stored at location x
+                                    0x24,          // Inputs are 36 bytes long
+                                    x,             // Store output over input (saves space)
+                                    0x20)          // Outputs are 32 bytes long
+
+                result := mload(x)                 // Load the result
+        }
+    }
+}

--- a/contracts/tests/TestCurrencyNetwork.sol
+++ b/contracts/tests/TestCurrencyNetwork.sol
@@ -19,17 +19,17 @@ contract TestCurrencyNetwork is CurrencyNetwork {
     }
 
     function setNetworkSettings(
-        string calldata _name,
-        string calldata _symbol,
-        uint8 _decimals,
+        string calldata _paramName,
+        string calldata _paramSymbol,
+        uint8 _paramDecimals,
         uint16 _capacityImbalanceFeeDivisor,
         int16 _defaultInterestRate,
         bool _customInterests,
         bool _preventMediatorInterests) external
     {
-        name = _name;
-        symbol = _symbol;
-        decimals = _decimals;
+        _name = _paramName;
+        _symbol = _paramSymbol;
+        _decimals = _paramDecimals;
         capacityImbalanceFeeDivisor = _capacityImbalanceFeeDivisor;
         defaultInterestRate = _defaultInterestRate;
         customInterests = _customInterests;

--- a/tests/test_currency_network_erc165.py
+++ b/tests/test_currency_network_erc165.py
@@ -26,7 +26,7 @@ def currency_network_contract(web3):
 def test_supports_interface(currency_network_contract, web3):
 
     # Calculate interface id from function signatures
-    ERC165_INTERFACE_ID = web3.sha3(text='supportsInterface(bytes4)')[:4].hex()
+    ERC165_INTERFACE_ID = web3.sha3(text="supportsInterface(bytes4)")[:4].hex()
 
     assert (
         currency_network_contract.functions.supportsInterface(
@@ -37,13 +37,20 @@ def test_supports_interface(currency_network_contract, web3):
 
     # Calculate interface id from function signatures
     CURRENCY_NETWORK_INTERFACE_ID = hex(
-        int.from_bytes(web3.sha3(text='name()')[:4], 'big') ^
-        int.from_bytes(web3.sha3(text='symbol()')[:4], 'big') ^
-        int.from_bytes(web3.sha3(text='decimals()')[:4], 'big') ^
-        int.from_bytes(web3.sha3(text='transfer(address,uint64,uint64,address[],bytes)')[:4], 'big') ^
-        int.from_bytes(web3.sha3(text='transferFrom(address,address,uint64,uint64,address[],bytes)')[:4], 'big') ^
-        int.from_bytes(web3.sha3(text='balance(address,address)')[:4], 'big') ^
-        int.from_bytes(web3.sha3(text='creditline(address,address)')[:4], 'big')
+        int.from_bytes(web3.sha3(text="name()")[:4], "big")
+        ^ int.from_bytes(web3.sha3(text="symbol()")[:4], "big")
+        ^ int.from_bytes(web3.sha3(text="decimals()")[:4], "big")
+        ^ int.from_bytes(
+            web3.sha3(text="transfer(address,uint64,uint64,address[],bytes)")[:4], "big"
+        )
+        ^ int.from_bytes(
+            web3.sha3(
+                text="transferFrom(address,address,uint64,uint64,address[],bytes)"
+            )[:4],
+            "big",
+        )
+        ^ int.from_bytes(web3.sha3(text="balance(address,address)")[:4], "big")
+        ^ int.from_bytes(web3.sha3(text="creditline(address,address)")[:4], "big")
     )
 
     assert (

--- a/tests/test_currency_network_erc165.py
+++ b/tests/test_currency_network_erc165.py
@@ -37,6 +37,9 @@ def test_supports_interface(currency_network_contract, web3):
 
     # Calculate interface id from function signatures
     CURRENCY_NETWORK_INTERFACE_ID = hex(
+        int.from_bytes(web3.sha3(text='name()')[:4], 'big') ^
+        int.from_bytes(web3.sha3(text='symbol()')[:4], 'big') ^
+        int.from_bytes(web3.sha3(text='decimals()')[:4], 'big') ^
         int.from_bytes(web3.sha3(text='transfer(address,uint64,uint64,address[],bytes)')[:4], 'big') ^
         int.from_bytes(web3.sha3(text='transferFrom(address,address,uint64,uint64,address[],bytes)')[:4], 'big') ^
         int.from_bytes(web3.sha3(text='balance(address,address)')[:4], 'big') ^

--- a/tests/test_currency_network_erc165.py
+++ b/tests/test_currency_network_erc165.py
@@ -31,11 +31,11 @@ def test_supports_interface(currency_network_contract):
         currency_network_contract.functions.supportsInterface(
             ERC165_INTERFACE_ID
         ).call()
-        == True
+        is True
     )
     assert (
         currency_network_contract.functions.supportsInterface(
             CURRENCY_NETWORK_INTERFACE_ID
         ).call()
-        == True
+        is True
     )

--- a/tests/test_currency_network_erc165.py
+++ b/tests/test_currency_network_erc165.py
@@ -1,0 +1,41 @@
+#! pytest
+import pytest
+
+from tldeploy.core import deploy_network
+from .conftest import EXPIRATION_TIME
+
+
+NETWORK_SETTING = {
+    "name": "TestCoin",
+    "symbol": "T",
+    "decimals": 6,
+    "fee_divisor": 0,
+    "default_interest_rate": 0,
+    "custom_interests": False,
+    "currency_network_contract_name": "TestCurrencyNetwork",
+    "set_account_enabled": True,
+    "expiration_time": EXPIRATION_TIME,
+}
+
+ERC165_INTERFACE_ID = "0x01ffc9a7"
+CURRENCY_NETWORK_INTERFACE_ID = "0xdcd45f8a"
+
+
+@pytest.fixture
+def currency_network_contract(web3):
+    return deploy_network(web3, **NETWORK_SETTING)
+
+
+def test_supports_interface(currency_network_contract):
+    assert (
+        currency_network_contract.functions.supportsInterface(
+            ERC165_INTERFACE_ID
+        ).call()
+        == True
+    )
+    assert (
+        currency_network_contract.functions.supportsInterface(
+            CURRENCY_NETWORK_INTERFACE_ID
+        ).call()
+        == True
+    )

--- a/tests/test_currency_network_erc165.py
+++ b/tests/test_currency_network_erc165.py
@@ -17,22 +17,32 @@ NETWORK_SETTING = {
     "expiration_time": EXPIRATION_TIME,
 }
 
-ERC165_INTERFACE_ID = "0x01ffc9a7"
-CURRENCY_NETWORK_INTERFACE_ID = "0xdcd45f8a"
-
 
 @pytest.fixture
 def currency_network_contract(web3):
     return deploy_network(web3, **NETWORK_SETTING)
 
 
-def test_supports_interface(currency_network_contract):
+def test_supports_interface(currency_network_contract, web3):
+
+    # Calculate interface id from function signatures
+    ERC165_INTERFACE_ID = web3.sha3(text='supportsInterface(bytes4)')[:4].hex()
+
     assert (
         currency_network_contract.functions.supportsInterface(
             ERC165_INTERFACE_ID
         ).call()
         is True
     )
+
+    # Calculate interface id from function signatures
+    CURRENCY_NETWORK_INTERFACE_ID = hex(
+        int.from_bytes(web3.sha3(text='transfer(address,uint64,uint64,address[],bytes)')[:4], 'big') ^
+        int.from_bytes(web3.sha3(text='transferFrom(address,address,uint64,uint64,address[],bytes)')[:4], 'big') ^
+        int.from_bytes(web3.sha3(text='balance(address,address)')[:4], 'big') ^
+        int.from_bytes(web3.sha3(text='creditline(address,address)')[:4], 'big')
+    )
+
     assert (
         currency_network_contract.functions.supportsInterface(
             CURRENCY_NETWORK_INTERFACE_ID

--- a/tests/test_currency_network_erc165.py
+++ b/tests/test_currency_network_erc165.py
@@ -13,7 +13,7 @@ NETWORK_SETTING = {
     "default_interest_rate": 0,
     "custom_interests": False,
     "currency_network_contract_name": "TestCurrencyNetwork",
-    "set_account_enabled": True,
+    "account_management_enabled": True,
     "expiration_time": EXPIRATION_TIME,
 }
 

--- a/tests/test_currency_network_registry.py
+++ b/tests/test_currency_network_registry.py
@@ -33,25 +33,25 @@ def currency_network_registry_contract(deploy_contract):
 def initialized_currency_network_registry_contract(
     currency_network_registry_contract, currency_network_contract
 ):
-    currency_network_registry_contract.functions.addNetwork(
+    currency_network_registry_contract.functions.addCurrencyNetwork(
         currency_network_contract.address
     ).transact()
     return currency_network_registry_contract
 
 
 def test_add_network(currency_network_registry_contract, currency_network_contract):
-    assert currency_network_registry_contract.functions.getNetworkCount().call() == 0
-    currency_network_registry_contract.functions.addNetwork(
+    assert currency_network_registry_contract.functions.getCurrencyNetworkCount().call() == 0
+    currency_network_registry_contract.functions.addCurrencyNetwork(
         currency_network_contract.address
     ).transact()
-    assert currency_network_registry_contract.functions.getNetworkCount().call() == 1
+    assert currency_network_registry_contract.functions.getCurrencyNetworkCount().call() == 1
 
 
 def test_add_network_once(
     initialized_currency_network_registry_contract, currency_network_contract
 ):
     with pytest.raises(eth_tester.exceptions.TransactionFailed):
-        initialized_currency_network_registry_contract.functions.addNetwork(
+        initialized_currency_network_registry_contract.functions.addCurrencyNetwork(
             currency_network_contract.address
         ).transact()
 
@@ -60,7 +60,7 @@ def test_get_address(
     initialized_currency_network_registry_contract, currency_network_contract
 ):
     assert (
-        initialized_currency_network_registry_contract.functions.getNetworkAddress(
+        initialized_currency_network_registry_contract.functions.getCurrencyNetworkAddress(
             0
         ).call()
         == currency_network_contract.address
@@ -72,7 +72,7 @@ def test_get_metadata(
     currency_network_contract,
     default_account,
 ):
-    metadata = initialized_currency_network_registry_contract.functions.getNetworkMetadata(
+    metadata = initialized_currency_network_registry_contract.functions.getCurrencyNetworkMetadata(
         currency_network_contract.address
     ).call()
     assert metadata[0] == default_account
@@ -82,18 +82,18 @@ def test_get_metadata(
 
 
 def test_no_events(currency_network_registry_contract):
-    events = currency_network_registry_contract.events.NetworkAdded.createFilter(
+    events = currency_network_registry_contract.events.CurrencyNetworkAdded.createFilter(
         fromBlock=0
     ).get_all_entries()
     assert len(events) == 0
 
 
 def test_add_event(initialized_currency_network_registry_contract, default_account):
-    events = initialized_currency_network_registry_contract.events.NetworkAdded.createFilter(
+    events = initialized_currency_network_registry_contract.events.CurrencyNetworkAdded.createFilter(
         fromBlock=0
     ).get_all_entries()
     assert len(events) == 1
-    assert events[0]["event"] == "NetworkAdded"
+    assert events[0]["event"] == "CurrencyNetworkAdded"
     assert events[0]["args"]["_author"] == default_account
     assert events[0]["args"]["_name"] == NETWORK_SETTING["name"]
     assert events[0]["args"]["_symbol"] == NETWORK_SETTING["symbol"]

--- a/tests/test_currency_network_registry.py
+++ b/tests/test_currency_network_registry.py
@@ -40,11 +40,17 @@ def initialized_currency_network_registry_contract(
 
 
 def test_add_network(currency_network_registry_contract, currency_network_contract):
-    assert currency_network_registry_contract.functions.getCurrencyNetworkCount().call() == 0
+    assert (
+        currency_network_registry_contract.functions.getCurrencyNetworkCount().call()
+        == 0
+    )
     currency_network_registry_contract.functions.addCurrencyNetwork(
         currency_network_contract.address
     ).transact()
-    assert currency_network_registry_contract.functions.getCurrencyNetworkCount().call() == 1
+    assert (
+        currency_network_registry_contract.functions.getCurrencyNetworkCount().call()
+        == 1
+    )
 
 
 def test_add_network_once(

--- a/tests/test_currency_network_registry.py
+++ b/tests/test_currency_network_registry.py
@@ -100,7 +100,7 @@ def test_add_event(initialized_currency_network_registry_contract, default_accou
     ).get_all_entries()
     assert len(events) == 1
     assert events[0]["event"] == "CurrencyNetworkAdded"
-    assert events[0]["args"]["_author"] == default_account
+    assert events[0]["args"]["_registeredBy"] == default_account
     assert events[0]["args"]["_name"] == NETWORK_SETTING["name"]
     assert events[0]["args"]["_symbol"] == NETWORK_SETTING["symbol"]
     assert events[0]["args"]["_decimals"] == NETWORK_SETTING["decimals"]

--- a/tests/test_currency_network_registry.py
+++ b/tests/test_currency_network_registry.py
@@ -14,7 +14,7 @@ NETWORK_SETTING = {
     "default_interest_rate": 0,
     "custom_interests": False,
     "currency_network_contract_name": "TestCurrencyNetwork",
-    "set_account_enabled": True,
+    "account_management_enabled": True,
     "expiration_time": EXPIRATION_TIME,
 }
 

--- a/tests/test_currency_network_registry.py
+++ b/tests/test_currency_network_registry.py
@@ -1,0 +1,100 @@
+#! pytest
+import pytest
+import eth_tester.exceptions
+
+from tldeploy.core import deploy_network
+from .conftest import EXPIRATION_TIME
+
+
+NETWORK_SETTING = {
+    "name": "TestCoin",
+    "symbol": "T",
+    "decimals": 6,
+    "fee_divisor": 0,
+    "default_interest_rate": 0,
+    "custom_interests": False,
+    "currency_network_contract_name": "TestCurrencyNetwork",
+    "set_account_enabled": True,
+    "expiration_time": EXPIRATION_TIME,
+}
+
+
+@pytest.fixture
+def currency_network_contract(web3):
+    return deploy_network(web3, **NETWORK_SETTING)
+
+
+@pytest.fixture
+def currency_network_registry_contract(deploy_contract):
+    return deploy_contract("CurrencyNetworkRegistry")
+
+
+@pytest.fixture
+def initialized_currency_network_registry_contract(
+    currency_network_registry_contract, currency_network_contract
+):
+    currency_network_registry_contract.functions.addNetwork(
+        currency_network_contract.address
+    ).transact()
+    return currency_network_registry_contract
+
+
+def test_add_network(currency_network_registry_contract, currency_network_contract):
+    assert currency_network_registry_contract.functions.getNetworkCount().call() == 0
+    currency_network_registry_contract.functions.addNetwork(
+        currency_network_contract.address
+    ).transact()
+    assert currency_network_registry_contract.functions.getNetworkCount().call() == 1
+
+
+def test_add_network_once(
+    initialized_currency_network_registry_contract, currency_network_contract
+):
+    with pytest.raises(eth_tester.exceptions.TransactionFailed):
+        initialized_currency_network_registry_contract.functions.addNetwork(
+            currency_network_contract.address
+        ).transact()
+
+
+def test_get_address(
+    initialized_currency_network_registry_contract, currency_network_contract
+):
+    assert (
+        initialized_currency_network_registry_contract.functions.getNetworkAddress(
+            0
+        ).call()
+        == currency_network_contract.address
+    )
+
+
+def test_get_metadata(
+    initialized_currency_network_registry_contract,
+    currency_network_contract,
+    default_account,
+):
+    metadata = initialized_currency_network_registry_contract.functions.getNetworkMetadata(
+        currency_network_contract.address
+    ).call()
+    assert metadata[0] == default_account
+    assert metadata[1] == NETWORK_SETTING["name"]
+    assert metadata[2] == NETWORK_SETTING["symbol"]
+    assert metadata[3] == NETWORK_SETTING["decimals"]
+
+
+def test_no_events(currency_network_registry_contract):
+    events = currency_network_registry_contract.events.NetworkAdded.createFilter(
+        fromBlock=0
+    ).get_all_entries()
+    assert len(events) == 0
+
+
+def test_add_event(initialized_currency_network_registry_contract, default_account):
+    events = initialized_currency_network_registry_contract.events.NetworkAdded.createFilter(
+        fromBlock=0
+    ).get_all_entries()
+    assert len(events) == 1
+    assert events[0]["event"] == "NetworkAdded"
+    assert events[0]["args"]["_author"] == default_account
+    assert events[0]["args"]["_name"] == NETWORK_SETTING["name"]
+    assert events[0]["args"]["_symbol"] == NETWORK_SETTING["symbol"]
+    assert events[0]["args"]["_decimals"] == NETWORK_SETTING["decimals"]


### PR DESCRIPTION
Implement currency network registry.

Closes #228 

In addition to the requirements mentioned in #228 I added the interface check anyways. If we really don't want it, we should remove the logic from the add function, but this way the user can be sure they are dealing with something resembling a currency network.