### PR TITLE
Feature/delegate fees in identity

### DIFF
--- a/contracts/CurrencyNetwork.sol
+++ b/contracts/CurrencyNetwork.sol
@@ -33,6 +33,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
     mapping (address => ItSet.AddressSet) internal friends;
     // list of all users of the system
     ItSet.AddressSet internal users;
+    // mapping of a pair of user to the signed debt in the point of view of the lowest address
+    mapping (bytes32 => int) public debt;
     // map each user to its onboarder
     mapping (address => address) public onboarder;
     // value in the mapping for users that do not have an onboarder
@@ -521,6 +523,23 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
             _mtime,
             _balance
         );
+    }
+
+    function increaseDebt(address creditor, int value) external {
+        address debtor = msg.sender;
+        if (debtor < creditor) {
+            debt[uniqueIdentifier(debtor, creditor)] += value;
+        } else {
+            debt[uniqueIdentifier(debtor, creditor)] -= value;
+        }
+    }
+
+    function getDebt(address debtor, address creditor) external view returns (int256) {
+        if (debtor < creditor) {
+            return debt[uniqueIdentifier(debtor, creditor)];
+        } else {
+            return - debt[uniqueIdentifier(debtor, creditor)];
+        }
     }
 
     /**

--- a/contracts/CurrencyNetwork.sol
+++ b/contracts/CurrencyNetwork.sol
@@ -525,6 +525,11 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         );
     }
 
+    /**
+     * @notice Used to increase the debt tracked by the currency network of msg.sender towards creditor address
+     * @param creditor The address towards which msg.sender increases its debt
+     * @param value The value to increase the debt by
+     */
     function increaseDebt(address creditor, uint64 value) external {
         address debtor = msg.sender;
         int72 oldDebt = debt[uniqueIdentifier(debtor, creditor)];
@@ -535,10 +540,16 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
         } else {
             int72 newDebt = oldDebt - value;
             assert(newDebt < oldDebt);
-            debt[uniqueIdentifier(debtor, creditor)] -= value;
+            debt[uniqueIdentifier(debtor, creditor)] = newDebt;
         }
     }
 
+    /**
+     * @notice Get the debt owed by debtor to creditor, may be negative if creditor owes debtor
+     * @param debtor The address of which we query the debt
+     * @param creditor The address towards which the debtor owes money
+     * @return the debt of the debtor to the creditor, equal to the opposite of the debt of the creditor to the debtor
+     */
     function getDebt(address debtor, address creditor) external view returns (int256) {
         if (debtor < creditor) {
             return debt[uniqueIdentifier(debtor, creditor)];

--- a/contracts/debtTrackingInterface.sol
+++ b/contracts/debtTrackingInterface.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.5.8;
+
+
+interface debtTrackingInterface {
+
+    event DebtUpdate(address _debtor, address _creditor, int72 _newDebt);
+
+    function increaseDebt(address creditor, uint64 value) external;
+
+    function getDebt(address debtor, address creditor) external view returns (int256);
+}

--- a/contracts/tests/TestContract.sol
+++ b/contracts/tests/TestContract.sol
@@ -1,7 +1,10 @@
 pragma solidity ^0.5.8;
 
+import "../debtTrackingInterface.sol";
 
-contract TestContract {
+
+// Test contract used for testing identity contract meta transaction features
+contract TestContract is debtTrackingInterface {
 
     event TestEvent(
         address from,
@@ -9,6 +12,15 @@ contract TestContract {
         bytes data,
         int argument
     );
+
+    event DebtIncrease(int72 value, address debtor, address creditor);
+
+    function increaseDebt(address creditor, uint64 value) external {
+    }
+
+    function getDebt(address debtor, address creditor) external view returns (int256) {
+        return 0;
+    }
 
     function testFunction(int argument) public payable {
         address from = msg.sender;

--- a/contracts/tests/TestContract.sol
+++ b/contracts/tests/TestContract.sol
@@ -13,7 +13,7 @@ contract TestContract is debtTrackingInterface {
         int argument
     );
 
-    event DebtIncrease(int72 value, address debtor, address creditor);
+    event DebtUpdate(address _debtor, address _creditor, int72 _newDebt);
 
     function increaseDebt(address creditor, uint64 value) external {
     }

--- a/contracts/tests/TestIdentity.sol
+++ b/contracts/tests/TestIdentity.sol
@@ -15,6 +15,8 @@ contract TestIdentity is Identity {
         address to,
         uint256 value,
         bytes memory data,
+        uint64 fees,
+        address currencyNetworkOfFees,
         uint256 nonce,
         bytes memory extraHash
     )
@@ -27,6 +29,8 @@ contract TestIdentity is Identity {
             to,
             value,
             data,
+            fees,
+            currencyNetworkOfFees,
             nonce,
             extraHash
         );

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,8 @@ import tldeploy.core
 
 # increase eth_tester's GAS_LIMIT
 # Otherwise we can't deploy our contract
-assert eth_tester.backends.pyevm.main.GENESIS_GAS_LIMIT < 6 * 10 ** 6
-eth_tester.backends.pyevm.main.GENESIS_GAS_LIMIT = 6 * 10 ** 6
+assert eth_tester.backends.pyevm.main.GENESIS_GAS_LIMIT < 8 * 10 ** 6
+eth_tester.backends.pyevm.main.GENESIS_GAS_LIMIT = 8 * 10 ** 6
 
 
 EXTRA_DATA = b"\x124Vx\x124Vx\x124Vx\x124Vx"

--- a/tests/test_currency_network_basics.py
+++ b/tests/test_currency_network_basics.py
@@ -850,3 +850,22 @@ def test_enabled_set_account(currency_network_contract, accounts):
     assert network.functions.balanceOf(accounts[0]).call() == 100
     network.functions.setAccountDefaultInterests(*account_no_interest).transact()
     assert network.functions.balanceOf(accounts[0]).call() == 200
+
+
+@pytest.mark.parametrize("creditor, debtor", [(0, 1), (1, 0)])
+def test_increasing_debt(currency_network_contract, accounts, creditor, debtor):
+    debt_value = 123
+
+    currency_network_contract.functions.increaseDebt(
+        accounts[debtor], debt_value
+    ).transact({"from": accounts[creditor]})
+
+    debt = currency_network_contract.functions.getDebt(
+        accounts[creditor], accounts[debtor]
+    ).call()
+    reverse_debt = currency_network_contract.functions.getDebt(
+        accounts[debtor], accounts[creditor]
+    ).call()
+
+    assert debt == debt_value
+    assert reverse_debt == -debt_value

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -119,7 +119,7 @@ def test_signature_not_owner(test_identity_contract, account_keys):
     ).call()
 
 
-def test_wrong_signature_from_owner(test_identity_contract, owner_key, accounts):
+def test_wrong_signature_from_owner(test_identity_contract, owner_key):
 
     data = (1234).to_bytes(10, byteorder="big")
     wrong_data = (12345678).to_bytes(10, byteorder="big")
@@ -129,6 +129,45 @@ def test_wrong_signature_from_owner(test_identity_contract, owner_key, accounts)
     assert not test_identity_contract.functions.validateSignature(
         wrong_data, signature
     ).call()
+
+
+def test_meta_transaction_signature_corresponds_to_clientlib_signature(
+    identity, owner_key
+):
+    # Tests that the signature obtained from the contracts and the clientlib implementation match,
+    # If this test needs to be changed, the corresponding test in the clientlib should also be changed
+    # See: clientlib/tests/unit/IdentityWallet.test.ts: 'should sign meta-transaction'
+    from_ = "0xF2E246BB76DF876Cef8b38ae84130F4F55De395b"
+    to = "0x51a240271AB8AB9f9a21C82d9a85396b704E164d"
+    value = 0
+    data = "0x46432830000000000000000000000000000000000000000000000000000000000000000a"
+    fees = 1
+    currency_network_of_fees = "0x51a240271AB8AB9f9a21C82d9a85396b704E164d"
+    extra_data = "0x"
+    nonce = 1
+
+    meta_transaction = MetaTransaction(
+        from_=from_,
+        to=to,
+        value=value,
+        data=data,
+        fees=fees,
+        currency_network_of_fees=currency_network_of_fees,
+        extra_data=extra_data,
+        nonce=nonce,
+    )
+
+    signature = identity.signed_meta_transaction(meta_transaction).signature
+
+    assert (
+        str(owner_key)
+        == "0x0000000000000000000000000000000000000000000000000000000000000001"
+    )
+    assert (
+        signature.hex()
+        == "02a3c9abd0de925653c188b7f2e6e79ca032037371ef12a560116595508a"
+        "51b65c1e4692878a87b491ef28e9ee560f7de0f2cb3f0981215134522750d42edce501"
+    )
 
 
 def test_delegated_transaction_hash(test_identity_contract, test_contract, accounts):


### PR DESCRIPTION
closes: https://github.com/trustlines-protocol/contracts/issues/236
closes: https://github.com/trustlines-protocol/contracts/issues/237

Based on: https://github.com/trustlines-protocol/contracts/pull/239

Add function to provide fee information to identity contract, update identity.py to make it work.
Rename `delegator` to `delegate` since it was a language mistake. It is a breaking change for the relay server.