### PR TITLE
Upgrade ethlint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
       - run:
           name: Install ethlint (=solium)
           command: |
-            npm install -g 'ethlint@>=1.0.9'
+            npm install -g 'ethlint@1.2.5'
       - run:
           name: Run solium
           command: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     - id: no-commit-to-branch
       args: [--branch, develop, --branch, master]
 -   repo: https://github.com/schmir/ethlint-pre-commit.git
-    rev: ceedc72aa232b9391840256c7781226a3e238b1a
+    rev: 0.3.0
     hooks:
     - id: ethlint
       exclude: ^(contracts/lib/|contracts/tokens)


### PR DESCRIPTION
see discussion in rocketchat.
pre-commit now detects the same errors that circleci does:
```
~/trustlines/protocol/contracts (git)-[upgrade-ethlint] % pre-commit run -a
black....................................................................Passed
Check for added large files..............................................Passed
Check python ast.........................................................Passed
Check for byte-order marker..............................................Passed
Check for case conflicts.................................................Passed
Check JSON...............................................................Passed
Check for merge conflicts................................................Passed
Check Yaml...............................................................Passed
Debug Statements (Python)................................................Passed
Fix End of Files.........................................................Passed
Flake8...................................................................Passed
Trim Trailing Whitespace.................................................Passed
Don't commit to branch...................................................Passed
Run ethlint..............................................................Failed
hookid: ethlint

contracts/tests/TestContract.sol:18:67: warning: Code contains empty block [no-empty-blocks]
contracts/Exchange.sol:132:8: error: Error message exceeds max length of 76 characters [error-reason]
contracts/Exchange.sol:136:8: error: Error message exceeds max length of 76 characters [error-reason]
contracts/Exchange.sol:248:8: error: Error message exceeds max length of 76 characters [error-reason]
contracts/Exchange.sol:376:8: error: Error message exceeds max length of 76 characters [error-reason]
contracts/CurrencyNetwork.sol:173:8: error: Error message exceeds max length of 76 characters [error-reason]
contracts/CurrencyNetwork.sol:983:12: error: Error message exceeds max length of 76 characters [error-reason]

mypy.....................................................................Passed
pre-commit run -a  11.46s user 1.31s system 357% cpu 3.571 total
```