### PR TITLE
Make expiration of currency networks optional

### DIFF
--- a/contracts/CurrencyNetwork.sol
+++ b/contracts/CurrencyNetwork.sol
@@ -147,7 +147,8 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
      * @param _customInterests Flag to allow or disallow trustlines to have custom interests
      * @param _preventMediatorInterests Flag to allow or disallow transactions resulting in loss of interests for
      *         intermediaries, unless the transaction exclusively reduces balances
-     * @param _expirationTime Time after which the currency network is frozen and cannot be used anymore
+     * @param _expirationTime Time after which the currency network is frozen and cannot be used anymore. Setting
+     *         this value to zero disables freezing.
      */
     function init(
         string calldata _name,
@@ -175,7 +176,10 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
             "Prevent mediator interest cannot be set without using custom interests."
         );
 
-        require(_expirationTime > now, "Expiration time must be in the future.");
+        require(
+            _expirationTime == 0 || _expirationTime > now,
+            "Expiration time must be either in the future or zero to disable it."
+        );
 
         name = _name;
         symbol = _symbol;
@@ -604,6 +608,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Ownable, Authorizable, Des
     }
 
     function freezeNetwork() external {
+        require(expirationTime != 0, "The currency network has disabled freezing.");
         require(expirationTime <= now, "The currency network cannot be frozen yet.");
         isNetworkFrozen = true;
     }

--- a/py-deploy/tldeploy/cli.py
+++ b/py-deploy/tldeploy/cli.py
@@ -99,16 +99,20 @@ currency_network_contract_name_option = click.option(
 @currency_network_contract_name_option
 @click.option(
     "--expiration-time",
-    help="Expiration time of the currency network after which it will be frozen (0 means disabled)",
+    help=(
+        "Expiration time of the currency network after which it will be frozen (0 means disabled). "
+        "Per default the network does not expire."
+    ),
     required=False,
     type=int,
-    default=0,  # disabled
-    show_default=True,
 )
 @click.option(
     "--expiration-date",
-    help="Expiration date of the currency network after which it will be frozen, "
-    "(e.g. '2020-09-28', '2020-09-28T13:56')",
+    help=(
+        "Expiration date of the currency network after which it will be frozen "
+        "(e.g. '2020-09-28', '2020-09-28T13:56'). "
+        "Per default the network does not expire."
+    ),
     type=str,
     required=False,
     metavar="DATE",
@@ -144,10 +148,13 @@ def currencynetwork(
             "Prevent mediator interests is not necessary if custom interests are disabled."
         )
 
-    if expiration_date is not None and expiration_time != 0:
+    if expiration_date is not None and expiration_time is not None:
         raise click.BadParameter(
             f"Both --expiration-date and --expiration-times have been specified."
         )
+
+    if expiration_date is None and expiration_time is None:
+        expiration_time = 0
 
     if expiration_date is not None:
         expiration_time = int(expiration_date.timestamp())

--- a/py-deploy/tldeploy/cli.py
+++ b/py-deploy/tldeploy/cli.py
@@ -99,9 +99,10 @@ currency_network_contract_name_option = click.option(
 @currency_network_contract_name_option
 @click.option(
     "--expiration-time",
-    help="Expiration time of the currency network after which it will be frozen",
+    help="Expiration time of the currency network after which it will be frozen (disabled by default)",
     required=False,
     type=int,
+    default=0,  # disabled
     show_default=True,
 )
 @click.option(
@@ -143,14 +144,11 @@ def currencynetwork(
             "Prevent mediator interests is not necessary if custom interests are disabled."
         )
 
-    if expiration_date is not None and expiration_time is not None:
+    if expiration_date is not None and expiration_time != 0:
         raise click.BadParameter(
             f"Both --expiration-date and --expiration-times have been specified."
         )
-    if expiration_date is None and expiration_time is None:
-        raise click.BadParameter(
-            f"Please specify an expiration limit with --expiration-date or --expiration-time."
-        )
+
     if expiration_date is not None:
         expiration_time = int(expiration_date.timestamp())
 

--- a/py-deploy/tldeploy/cli.py
+++ b/py-deploy/tldeploy/cli.py
@@ -99,7 +99,7 @@ currency_network_contract_name_option = click.option(
 @currency_network_contract_name_option
 @click.option(
     "--expiration-time",
-    help="Expiration time of the currency network after which it will be frozen (disabled by default)",
+    help="Expiration time of the currency network after which it will be frozen (0 means disabled)",
     required=False,
     type=int,
     default=0,  # disabled


### PR DESCRIPTION
This includes:
- extend currency network contract to allow disabling freezing on initialization
- disable freezing per default for deploy tool

Closes: trustlines-network/project#682