### PR TITLE
Pin ethlint to 1.2.5 on circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
       - run:
           name: Install ethlint (=solium)
           command: |
-            npm install -g 'ethlint@>=1.2.5'
+            npm install -g 'ethlint@1.2.5'
       - run:
           name: Run solium
           command: |


### PR DESCRIPTION
With 'ethlint@>=1.2.5', we would automatically use a new version on
circleci if it becomes available.

Also see https://github.com/trustlines-protocol/contracts/pull/249 and
https://github.com/trustlines-protocol/contracts/pull/250