### PR TITLE
Move setAccount function back to TestCurrencyNetwork

### DIFF
--- a/contracts/tests/TestCurrencyNetwork.sol
+++ b/contracts/tests/TestCurrencyNetwork.sol
@@ -72,6 +72,85 @@ contract TestCurrencyNetwork is CurrencyNetwork {
         );
     }
 
+    /**
+    * Set the trustline account between two users.
+    * Can be removed once structs are supported in the ABI
+    */
+    function setAccount(
+        address _a,
+        address _b,
+        uint64 _creditlineGiven,
+        uint64 _creditlineReceived,
+        int16 _interestRateGiven,
+        int16 _interestRateReceived,
+        bool _isFrozen,
+        uint16 _feesOutstandingA,
+        uint16 _feesOutstandingB,
+        uint32 _mtime,
+        int72 _balance
+    )
+        external
+    {
+        require(
+            customInterests ||
+            (_interestRateGiven == defaultInterestRate && _interestRateReceived == defaultInterestRate),
+            "Interest rates given and received must be equal to default interest rates."
+        );
+        if (customInterests) {
+            require(
+                _interestRateGiven >= 0 &&
+                _interestRateReceived >= 0,
+                "Only positive interest rates are supported."
+            );
+        }
+
+        _setAccount(
+            _a,
+            _b,
+            _creditlineGiven,
+            _creditlineReceived,
+            _interestRateGiven,
+            _interestRateReceived,
+            _isFrozen,
+            _feesOutstandingA,
+            _feesOutstandingB,
+            _mtime,
+            _balance
+        );
+    }
+
+    /**
+    * Set the trustline account between two users with default interests.
+    * Can be removed once structs are supported in the ABI
+    */
+    function setAccountDefaultInterests(
+        address _a,
+        address _b,
+        uint64 _creditlineGiven,
+        uint64 _creditlineReceived,
+        bool _isFrozen,
+        uint16 _feesOutstandingA,
+        uint16 _feesOutstandingB,
+        uint32 _mtime,
+        int72 _balance
+    )
+        external
+    {
+        _setAccount(
+            _a,
+            _b,
+            _creditlineGiven,
+            _creditlineReceived,
+            defaultInterestRate,
+            defaultInterestRate,
+            _isFrozen,
+            _feesOutstandingA,
+            _feesOutstandingB,
+            _mtime,
+            _balance
+        );
+    }
+
     function testCalculateFees(uint64 _imbalanceGenerated, uint16 _capacityImbalanceFeeDivisor)
         public pure
         returns (uint64)
@@ -94,5 +173,41 @@ contract TestCurrencyNetwork is CurrencyNetwork {
         returns (uint64)
     {
         return _imbalanceGenerated(_value, _balance);
+    }
+
+    function _setAccount(
+        address _a,
+        address _b,
+        uint64 _creditlineGiven,
+        uint64 _creditlineReceived,
+        int16 _interestRateGiven,
+        int16 _interestRateReceived,
+        bool _isFrozen,
+        uint16 _feesOutstandingA,
+        uint16 _feesOutstandingB,
+        uint32 _mtime,
+        int72 _balance
+    )
+        internal
+    {
+        TrustlineAgreement memory trustlineAgreement;
+        trustlineAgreement.creditlineGiven = _creditlineGiven;
+        trustlineAgreement.creditlineReceived = _creditlineReceived;
+        trustlineAgreement.interestRateGiven = _interestRateGiven;
+        trustlineAgreement.interestRateReceived = _interestRateReceived;
+        trustlineAgreement.isFrozen = _isFrozen;
+
+        TrustlineBalances memory trustlineBalances;
+        trustlineBalances.feesOutstandingA = _feesOutstandingA;
+        trustlineBalances.feesOutstandingB = _feesOutstandingB;
+        trustlineBalances.mtime = _mtime;
+        trustlineBalances.balance = _balance;
+
+        _storeTrustlineAgreement(_a, _b, trustlineAgreement);
+        _storeTrustlineBalances(_a, _b, trustlineBalances);
+
+        addToUsersAndFriends(_a, _b);
+        _applyOnboardingRules(_a, owner);
+        _applyOnboardingRules(_b, owner);
     }
 }

--- a/py-deploy/tldeploy/core.py
+++ b/py-deploy/tldeploy/core.py
@@ -125,7 +125,6 @@ def deploy_network(
     prevent_mediator_interests=False,
     exchange_address=None,
     currency_network_contract_name=None,
-    account_management_enabled=False,
     transaction_options: Dict = None,
     private_key=None,
 ):
@@ -172,16 +171,6 @@ def deploy_network(
         )
         send_function_call_transaction(
             add_function_call,
-            web3=web3,
-            transaction_options=transaction_options,
-            private_key=private_key,
-        )
-        increase_transaction_options_nonce(transaction_options)
-
-    if account_management_enabled is False:
-        disable_function_call = currency_network.functions.disableAccountManagement()
-        send_function_call_transaction(
-            disable_function_call,
             web3=web3,
             transaction_options=transaction_options,
             private_key=private_key,

--- a/tests/test_close_trustline.py
+++ b/tests/test_close_trustline.py
@@ -19,7 +19,6 @@ NETWORK_SETTING = {
     "custom_interests": True,
     "prevent_mediator_interests": False,
     "currency_network_contract_name": "TestCurrencyNetwork",
-    "account_management_enabled": True,
     "expiration_time": EXPIRATION_TIME,
 }
 

--- a/tests/test_currency_network_basics.py
+++ b/tests/test_currency_network_basics.py
@@ -24,7 +24,6 @@ NETWORK_SETTING = {
     "default_interest_rate": 0,
     "custom_interests": False,
     "currency_network_contract_name": "TestCurrencyNetwork",
-    "account_management_enabled": True,
     "expiration_time": EXPIRATION_TIME,
 }
 
@@ -56,7 +55,6 @@ def currency_network_contract_custom_interest(web3):
         default_interest_rate=0,
         custom_interests=True,
         prevent_mediator_interests=False,
-        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
 
@@ -815,41 +813,6 @@ def test_overflow_max_transfer(currency_network_contract, accounts):
     )
     with pytest.raises(eth_tester.exceptions.TransactionFailed):
         contract.functions.transfer(B, 1, 0, [B], EXTRA_DATA).transact({"from": A})
-
-
-def test_disabled_set_account(currency_network_contract, accounts):
-    """
-    Tests that we cannot set an account when account_management_enabled is False.
-    """
-    network = currency_network_contract
-
-    network.functions.disableAccountManagement().transact()
-    assert network.functions.accountManagementEnabled().call() is False
-
-    account = (accounts[0], accounts[1], 100, 100, 0, 0, False, 0, 0, 0, 0)
-    account_no_interest = (accounts[0], accounts[1], 100, 100, False, 0, 0, 0, 0)
-
-    with pytest.raises(eth_tester.exceptions.TransactionFailed):
-        network.functions.setAccount(*account).transact()
-    with pytest.raises(eth_tester.exceptions.TransactionFailed):
-        network.functions.setAccountDefaultInterests(*account_no_interest).transact()
-
-
-def test_enabled_set_account(currency_network_contract, accounts):
-    """
-    Tests that we can set an account when account_management_enabled is True.
-    """
-    network = currency_network_contract
-
-    assert network.functions.accountManagementEnabled().call() is True
-
-    account = (accounts[0], accounts[1], 100, 100, 0, 0, False, 0, 0, 0, 0)
-    account_no_interest = (accounts[0], accounts[1], 200, 200, False, 0, 0, 0, 0)
-
-    network.functions.setAccount(*account).transact()
-    assert network.functions.balanceOf(accounts[0]).call() == 100
-    network.functions.setAccountDefaultInterests(*account_no_interest).transact()
-    assert network.functions.balanceOf(accounts[0]).call() == 200
 
 
 @pytest.mark.parametrize("creditor, debtor", [(0, 1), (1, 0)])

--- a/tests/test_currency_network_erc165.py
+++ b/tests/test_currency_network_erc165.py
@@ -13,7 +13,6 @@ NETWORK_SETTING = {
     "default_interest_rate": 0,
     "custom_interests": False,
     "currency_network_contract_name": "TestCurrencyNetwork",
-    "account_management_enabled": True,
     "expiration_time": EXPIRATION_TIME,
 }
 

--- a/tests/test_currency_network_fees.py
+++ b/tests/test_currency_network_fees.py
@@ -26,7 +26,6 @@ def currency_network_contract_with_trustlines(web3, accounts):
         symbol="T",
         decimals=6,
         fee_divisor=100,
-        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
     for (A, B, clAB, clBA) in trustlines:

--- a/tests/test_currency_network_freezing.py
+++ b/tests/test_currency_network_freezing.py
@@ -15,7 +15,6 @@ NETWORK_SETTING: Dict[str, Any] = {
     "default_interest_rate": 0,
     "custom_interests": False,
     "currency_network_contract_name": "TestCurrencyNetwork",
-    "account_management_enabled": True,
     "expiration_time": EXPIRATION_TIME,
 }
 

--- a/tests/test_currency_network_interests.py
+++ b/tests/test_currency_network_interests.py
@@ -30,7 +30,6 @@ def currency_network_contract_no_interests(web3):
         custom_interests=False,
         prevent_mediator_interests=False,
         currency_network_contract_name="TestCurrencyNetwork",
-        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
 
@@ -47,7 +46,6 @@ def currency_network_contract_default_interests(web3):
         custom_interests=False,
         prevent_mediator_interests=False,
         currency_network_contract_name="TestCurrencyNetwork",
-        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
 
@@ -64,7 +62,6 @@ def currency_network_contract_negative_interests(web3):
         custom_interests=False,
         prevent_mediator_interests=False,
         currency_network_contract_name="TestCurrencyNetwork",
-        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
 
@@ -81,7 +78,6 @@ def currency_network_contract_custom_interests_safe_ripple(web3):
         custom_interests=True,
         prevent_mediator_interests=True,
         currency_network_contract_name="TestCurrencyNetwork",
-        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
 

--- a/tests/test_currency_network_onboarding.py
+++ b/tests/test_currency_network_onboarding.py
@@ -11,7 +11,6 @@ NETWORK_SETTING = {
     "default_interest_rate": 0,
     "custom_interests": False,
     "currency_network_contract_name": "TestCurrencyNetwork",
-    "account_management_enabled": True,
     "expiration_time": EXPIRATION_TIME,
 }
 

--- a/tests/test_currency_network_receiver_pays.py
+++ b/tests/test_currency_network_receiver_pays.py
@@ -24,7 +24,6 @@ def currency_network_contract_with_trustlines(web3, accounts):
         decimals=6,
         fee_divisor=100,
         currency_network_contract_name="TestCurrencyNetwork",
-        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
     for (A, B, clAB, clBA) in trustlines:
@@ -43,7 +42,6 @@ def currency_network_contract_with_high_trustlines(web3, accounts):
         decimals=6,
         fee_divisor=100,
         currency_network_contract_name="TestCurrencyNetwork",
-        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
     creditline = 1000000

--- a/tests/test_currency_network_registry.py
+++ b/tests/test_currency_network_registry.py
@@ -14,7 +14,6 @@ NETWORK_SETTING = {
     "default_interest_rate": 0,
     "custom_interests": False,
     "currency_network_contract_name": "TestCurrencyNetwork",
-    "account_management_enabled": True,
     "expiration_time": EXPIRATION_TIME,
 }
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -44,7 +44,6 @@ def test_deploy_network(web3):
         default_interest_rate=100,
         custom_interests=False,
         prevent_mediator_interests=False,
-        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
 
@@ -53,5 +52,4 @@ def test_deploy_network(web3):
     assert network.functions.decimals().call() == 2
     assert network.functions.customInterests().call() is False
     assert network.functions.defaultInterestRate().call() == 100
-    assert network.functions.accountManagementEnabled().call() is True
     assert network.functions.expirationTime().call() == EXPIRATION_TIME

--- a/tests/test_exchange.py
+++ b/tests/test_exchange.py
@@ -48,7 +48,6 @@ def currency_network_contract_with_trustlines(web3, exchange_contract, accounts)
         decimals=6,
         fee_divisor=0,
         currency_network_contract_name="TestCurrencyNetwork",
-        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
     for (A, B, clAB, clBA) in trustlines:

--- a/tests/test_gas_costs.py
+++ b/tests/test_gas_costs.py
@@ -53,7 +53,6 @@ def currency_network_contract(web3):
         decimals=2,
         fee_divisor=100,
         currency_network_contract_name="TestCurrencyNetwork",
-        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
 
@@ -67,7 +66,6 @@ def currency_network_contract_with_trustlines(web3, accounts):
         decimals=2,
         fee_divisor=100,
         currency_network_contract_name="TestCurrencyNetwork",
-        account_management_enabled=True,
         expiration_time=EXPIRATION_TIME,
     )
     for (A, B, clAB, clBA) in trustlines:

--- a/tests/test_information_from_events.py
+++ b/tests/test_information_from_events.py
@@ -28,7 +28,6 @@ NETWORK_SETTING = {
     "default_interest_rate": 1000,
     "custom_interests": False,
     "currency_network_contract_name": "TestCurrencyNetwork",
-    "account_management_enabled": True,
     "expiration_time": EXPIRATION_TIME,
 }
 


### PR DESCRIPTION
Also remove the accountManagement parameter now useless in the contract

closes https://github.com/trustlines-protocol/contracts/issues/261