### PR TITLE
Prevent close trustline triangulated transfer overflow

### DIFF
--- a/contracts/CurrencyNetwork.sol
+++ b/contracts/CurrencyNetwork.sol
@@ -431,7 +431,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Authorizable, debtTracking
      */
     function closeTrustlineByTriangularTransfer(
         address _otherParty,
-        uint32 _maxFee,
+        uint64 _maxFee,
         address[] calldata _path
     )
         external
@@ -840,21 +840,10 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Authorizable, debtTracking
             false);
     }
 
-    /* close a trustline by doing a triangular transfer
-
-       this function receives the path along which to do the transfer. This path
-       is computed by the relay server based on the then current state of the
-       balance. In case the balance changed it's sign, the path will not have
-       the right 'shape' and the require statements below will revert the
-       transaction.
-
-       XXX This function is currently broken for balances which do not fit into
-       a uint32. We may repair that later when merging the interest changes.
-     */
     function _closeTrustlineByTriangularTransfer(
         address _from,
         address _otherParty,
-        uint32 _maxFee,
+        uint64 _maxFee,
         address[] memory _path)
         internal
     {
@@ -867,6 +856,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Authorizable, debtTracking
            may investigate what's cheaper gas-wise later.
         */
         TrustlineBalances memory balances = trustline.balances;
+
         if (balances.balance > 0) {
             require(
                 _path.length >= 2,
@@ -880,10 +870,11 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Authorizable, debtTracking
                 _path[0] == _otherParty,
                 "The first element of the path does not match with the _otherParty address."
             );
+            require(uint64(balances.balance) == balances.balance, "Cannot transfer too high values.");
             _mediatedTransferReceiverPays(
                 _from,
                 _from,
-                uint32(balances.balance),
+                uint64(balances.balance),
                 _maxFee,
                 _path,
                 ""
@@ -901,10 +892,11 @@ contract CurrencyNetwork is CurrencyNetworkInterface, Authorizable, debtTracking
                 _path[_path.length - 2] == _otherParty,
                 "The second to last element of the path has to be _otherParty address."
             );
+            require(uint64(-balances.balance) == - balances.balance, "Cannot transfer too high values.");
             _mediatedTransferSenderPays(
                 _from,
                 _from,
-                uint32(-balances.balance),
+                uint64(-balances.balance),
                 _maxFee,
                 _path,
                 ""

--- a/contracts/CurrencyNetwork.sol
+++ b/contracts/CurrencyNetwork.sol
@@ -21,8 +21,8 @@ import "./debtTrackingInterface.sol";
 contract CurrencyNetwork is CurrencyNetworkInterface, Authorizable, debtTrackingInterface, ERC165 {
 
     // Constants
-    int72 constant MAX_BALANCE = 2**71 - 1;
-    int72 constant MIN_BALANCE = - MAX_BALANCE; // for symmetry MIN_BALANCE needs to be the same absolute value like MAX_BALANCE
+    int72 constant MAX_BALANCE = 2**64 - 1;
+    int72 constant MIN_BALANCE = - MAX_BALANCE;
     int256 constant SECONDS_PER_YEAR = 60*60*24*365;
 
     using ItSet for ItSet.AddressSet;

--- a/tests/test_currency_network_interests.py
+++ b/tests/test_currency_network_interests.py
@@ -576,6 +576,7 @@ INTEREST_WIDTH = 16
 def test_interests_overflow(
     chain, currency_network_contract_custom_interests_safe_ripple, accounts
 ):
+    """Test that the interests will not put the balance above max uint64"""
     contract = currency_network_contract_custom_interests_safe_ripple
     current_time = int(time.time())
     chain.time_travel(current_time + 10)
@@ -601,12 +602,13 @@ def test_interests_overflow(
 
     balance = contract.functions.balance(accounts[0], accounts[1]).call()
 
-    assert balance + 1 == 2 ** (BALANCE_WIDTH - 1) - 1
+    assert balance + 1 == 2 ** CREDITLINE_WIDTH - 1
 
 
 def test_interests_underflow(
     chain, currency_network_contract_custom_interests_safe_ripple, accounts
 ):
+    """Test that the interests will not put the balance below min uint64"""
     contract = currency_network_contract_custom_interests_safe_ripple
     current_time = int(time.time())
     chain.time_travel(current_time + 10)
@@ -637,7 +639,7 @@ def test_interests_underflow(
     )
     balance = contract.functions.balance(accounts[0], accounts[1]).call()
 
-    assert balance - 1 == -(2 ** (BALANCE_WIDTH - 1) - 1)
+    assert balance - 1 == -(2 ** CREDITLINE_WIDTH - 1)
 
 
 def test_interests_over_change_in_trustline(


### PR DESCRIPTION
As transfer bigger than uint64 are not handled we should revert
triangulated transfer of such values
Also accept maxFees of uint64 in closeTrustlineByTriangulated...