### PR TITLE
Remove unused outstanding fees fields

### DIFF
--- a/contracts/CurrencyNetwork.sol
+++ b/contracts/CurrencyNetwork.sol
@@ -99,7 +99,6 @@ contract CurrencyNetwork is CurrencyNetworkInterface, CurrencyNetworkMetaData, A
     }
 
     struct TrustlineAgreement {
-
         uint64 creditlineGiven;       //  creditline given by A to B, always positive
         uint64 creditlineReceived;    //  creditline given by B to A, always positive
 
@@ -111,15 +110,10 @@ contract CurrencyNetwork is CurrencyNetworkInterface, CurrencyNetworkMetaData, A
     }
 
     struct TrustlineBalances {
-
-        uint16 feesOutstandingA;       //  fees outstanding by A
-        uint16 feesOutstandingB;       //  fees outstanding by B
-
         uint32 mtime;                  //  last time interests were applied
-
         int72 balance;                 //  balance between A and B, balance is >0 if B owes A, negative otherwise.
                                        //  balance(B,A) = - balance(A,B)
-        int120 padding;                //  fill up to 256 bit
+        int152 padding;                //  fill up to 256 bit
     }
 
     struct TrustlineRequest {
@@ -470,7 +464,7 @@ contract CurrencyNetwork is CurrencyNetworkInterface, CurrencyNetworkMetaData, A
     * Query the trustline between two users.
     * Can be removed once structs are supported in the ABI
     */
-    function getAccount(address _a, address _b) external view returns (int, int, int, int, bool, int, int, int, int) {
+    function getAccount(address _a, address _b) external view returns (int, int, int, int, bool, int, int) {
         Trustline memory trustline = _loadTrustline(_a, _b);
 
         return (
@@ -479,8 +473,6 @@ contract CurrencyNetwork is CurrencyNetworkInterface, CurrencyNetworkMetaData, A
             trustline.agreement.interestRateGiven,
             trustline.agreement.interestRateReceived,
             trustline.agreement.isFrozen || isNetworkFrozen,
-            trustline.balances.feesOutstandingA,
-            trustline.balances.feesOutstandingB,
             trustline.balances.mtime,
             trustline.balances.balance);
     }
@@ -912,8 +904,6 @@ contract CurrencyNetwork is CurrencyNetworkInterface, CurrencyNetworkMetaData, A
         if (_a < _b) {
             result = balances;
         } else {
-            result.feesOutstandingB = balances.feesOutstandingA;
-            result.feesOutstandingA = balances.feesOutstandingB;
             result.mtime = balances.mtime;
             result.balance = - balances.balance;
         }
@@ -952,14 +942,10 @@ contract CurrencyNetwork is CurrencyNetworkInterface, CurrencyNetworkMetaData, A
     function _storeTrustlineBalances(address _a, address _b, TrustlineBalances memory trustlineBalances) internal {
         TrustlineBalances storage storedTrustlineBalance = trustlines[uniqueIdentifier(_a, _b)].balances;
         if (_a < _b) {
-            storedTrustlineBalance.feesOutstandingA = trustlineBalances.feesOutstandingA;
-            storedTrustlineBalance.feesOutstandingB = trustlineBalances.feesOutstandingB;
             storedTrustlineBalance.mtime = trustlineBalances.mtime;
             storedTrustlineBalance.balance = trustlineBalances.balance;
             storedTrustlineBalance.padding = trustlineBalances.padding;
         } else {
-            storedTrustlineBalance.feesOutstandingA = trustlineBalances.feesOutstandingB;
-            storedTrustlineBalance.feesOutstandingB = trustlineBalances.feesOutstandingA;
             storedTrustlineBalance.mtime = trustlineBalances.mtime;
             storedTrustlineBalance.balance = - trustlineBalances.balance;
             storedTrustlineBalance.padding = trustlineBalances.padding;

--- a/contracts/tests/TestCurrencyNetwork.sol
+++ b/contracts/tests/TestCurrencyNetwork.sol
@@ -84,8 +84,6 @@ contract TestCurrencyNetwork is CurrencyNetwork {
         int16 _interestRateGiven,
         int16 _interestRateReceived,
         bool _isFrozen,
-        uint16 _feesOutstandingA,
-        uint16 _feesOutstandingB,
         uint32 _mtime,
         int72 _balance
     )
@@ -112,8 +110,6 @@ contract TestCurrencyNetwork is CurrencyNetwork {
             _interestRateGiven,
             _interestRateReceived,
             _isFrozen,
-            _feesOutstandingA,
-            _feesOutstandingB,
             _mtime,
             _balance
         );
@@ -129,8 +125,6 @@ contract TestCurrencyNetwork is CurrencyNetwork {
         uint64 _creditlineGiven,
         uint64 _creditlineReceived,
         bool _isFrozen,
-        uint16 _feesOutstandingA,
-        uint16 _feesOutstandingB,
         uint32 _mtime,
         int72 _balance
     )
@@ -144,8 +138,6 @@ contract TestCurrencyNetwork is CurrencyNetwork {
             defaultInterestRate,
             defaultInterestRate,
             _isFrozen,
-            _feesOutstandingA,
-            _feesOutstandingB,
             _mtime,
             _balance
         );
@@ -187,8 +179,6 @@ contract TestCurrencyNetwork is CurrencyNetwork {
         int16 _interestRateGiven,
         int16 _interestRateReceived,
         bool _isFrozen,
-        uint16 _feesOutstandingA,
-        uint16 _feesOutstandingB,
         uint32 _mtime,
         int72 _balance
     )
@@ -202,8 +192,6 @@ contract TestCurrencyNetwork is CurrencyNetwork {
         trustlineAgreement.isFrozen = _isFrozen;
 
         TrustlineBalances memory trustlineBalances;
-        trustlineBalances.feesOutstandingA = _feesOutstandingA;
-        trustlineBalances.feesOutstandingB = _feesOutstandingB;
         trustlineBalances.mtime = _mtime;
         trustlineBalances.balance = _balance;
 

--- a/tests/test_close_trustline.py
+++ b/tests/test_close_trustline.py
@@ -51,8 +51,6 @@ def currency_network_contract_with_trustlines(chain, web3, accounts, interest_ra
                 _interestRateGiven=interest_rate,
                 _interestRateReceived=interest_rate,
                 _isFrozen=False,
-                _feesOutstandingA=0,
-                _feesOutstandingB=0,
                 _mtime=current_time,
                 _balance=0,
             ).transact()
@@ -73,8 +71,6 @@ def ensure_trustline_closed(contract, address1, address2):
         0,
         0,
         False,
-        0,
-        0,
         0,
         0,
     ]

--- a/tests/test_currency_network_basics.py
+++ b/tests/test_currency_network_basics.py
@@ -37,7 +37,7 @@ def currency_network_contract_with_trustlines(web3, accounts):
     contract = deploy_network(web3, **NETWORK_SETTING)
     for (A, B, clAB, clBA) in trustlines:
         contract.functions.setAccount(
-            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0, 0, 0
+            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0
         ).transact()
     return contract
 
@@ -103,7 +103,7 @@ def test_friends(currency_network_contract_with_trustlines, accounts):
 def test_set_get_Account(currency_network_contract_custom_interest, accounts):
     contract = currency_network_contract_custom_interest
     contract.functions.setAccount(
-        accounts[0], accounts[1], 10, 20, 2, 3, False, 100, 200, 0, 4
+        accounts[0], accounts[1], 10, 20, 2, 3, False, 0, 4
     ).transact()
     assert contract.functions.getAccount(accounts[0], accounts[1]).call() == [
         10,
@@ -111,8 +111,6 @@ def test_set_get_Account(currency_network_contract_custom_interest, accounts):
         2,
         3,
         False,
-        100,
-        200,
         0,
         4,
     ]
@@ -122,13 +120,11 @@ def test_set_get_Account(currency_network_contract_custom_interest, accounts):
         3,
         2,
         False,
-        200,
-        100,
         0,
         -4,
     ]
     contract.functions.setAccount(
-        accounts[1], accounts[0], 10, 20, 2, 3, False, 100, 200, 0, 4
+        accounts[1], accounts[0], 10, 20, 2, 3, False, 0, 4
     ).transact()
     assert contract.functions.getAccount(accounts[1], accounts[0]).call() == [
         10,
@@ -136,8 +132,6 @@ def test_set_get_Account(currency_network_contract_custom_interest, accounts):
         2,
         3,
         False,
-        100,
-        200,
         0,
         4,
     ]
@@ -147,8 +141,6 @@ def test_set_get_Account(currency_network_contract_custom_interest, accounts):
         3,
         2,
         False,
-        200,
-        100,
         0,
         -4,
     ]
@@ -165,7 +157,7 @@ def test_creditlines(currency_network_contract_with_trustlines, accounts):
 def test_set_get_Account_default_interests(currency_network_contract, accounts):
     contract = currency_network_contract
     contract.functions.setAccountDefaultInterests(
-        accounts[0], accounts[1], 10, 20, False, 100, 200, 0, 4
+        accounts[0], accounts[1], 10, 20, False, 0, 4
     ).transact()
     # setAccount(address, address, creditLimit, creditLimit, interest, interest, feeOut, feeOut, mtime, balance)
     assert contract.functions.getAccount(accounts[0], accounts[1]).call() == [
@@ -174,8 +166,6 @@ def test_set_get_Account_default_interests(currency_network_contract, accounts):
         0,
         0,
         False,
-        100,
-        200,
         0,
         4,
     ]
@@ -185,13 +175,11 @@ def test_set_get_Account_default_interests(currency_network_contract, accounts):
         0,
         0,
         False,
-        200,
-        100,
         0,
         -4,
     ]
     contract.functions.setAccountDefaultInterests(
-        accounts[1], accounts[0], 10, 20, False, 100, 200, 0, 4
+        accounts[1], accounts[0], 10, 20, False, 0, 4
     ).transact()
     assert contract.functions.getAccount(accounts[1], accounts[0]).call() == [
         10,
@@ -199,8 +187,6 @@ def test_set_get_Account_default_interests(currency_network_contract, accounts):
         0,
         0,
         False,
-        100,
-        200,
         0,
         4,
     ]
@@ -210,8 +196,6 @@ def test_set_get_Account_default_interests(currency_network_contract, accounts):
         0,
         0,
         False,
-        200,
-        100,
         0,
         -4,
     ]
@@ -220,7 +204,7 @@ def test_set_get_Account_default_interests(currency_network_contract, accounts):
 def test_balance(currency_network_contract, accounts):
     contract = currency_network_contract
     contract.functions.setAccount(
-        accounts[0], accounts[1], 10, 20, 0, 0, False, 100, 200, 0, 4
+        accounts[0], accounts[1], 10, 20, 0, 0, False, 0, 4
     ).transact()
     assert contract.functions.balance(accounts[0], accounts[1]).call() == 4
     assert contract.functions.balance(accounts[1], accounts[0]).call() == -4
@@ -616,7 +600,7 @@ def test_update_trustline_with_custom_while_forbidden_lowering_interests(
 
     A, B, *rest = accounts
     contract.functions.setAccountDefaultInterests(
-        A, B, 200, 200, False, 0, 0, 0, 0
+        A, B, 200, 200, False, 0, 0
     ).transact()
 
     with pytest.raises(eth_tester.exceptions.TransactionFailed):
@@ -678,8 +662,6 @@ def test_setting_trustline_with_negative_interests_with_custom_interests(
             -1000,
             -1000,
             False,
-            0,
-            0,
             1442509455,
             100000000,
         ).transact()
@@ -809,7 +791,7 @@ def test_update_trustline_add_users(currency_network_contract, accounts):
 def test_update_set_account_add_users(currency_network_contract, accounts):
     contract = currency_network_contract
     A, B, *rest = accounts
-    contract.functions.setAccount(A, B, 50, 100, 0, 0, False, 0, 0, 0, 0).transact()
+    contract.functions.setAccount(A, B, 50, 100, 0, 0, False, 0, 0).transact()
     assert len(contract.functions.getUsers().call()) == 2
 
 

--- a/tests/test_currency_network_debt.py
+++ b/tests/test_currency_network_debt.py
@@ -40,7 +40,7 @@ def currency_network_contract_with_trustlines(web3, accounts):
     contract = deploy_network(web3, **NETWORK_SETTING)
     for (A, B, clAB, clBA) in trustlines:
         contract.functions.setAccount(
-            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0, 0, 0
+            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0
         ).transact()
     return contract
 

--- a/tests/test_currency_network_fees.py
+++ b/tests/test_currency_network_fees.py
@@ -30,7 +30,7 @@ def currency_network_contract_with_trustlines(web3, accounts):
     )
     for (A, B, clAB, clBA) in trustlines:
         contract.functions.setAccount(
-            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0, 0, 0
+            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0
         ).transact()
     return contract
 

--- a/tests/test_currency_network_freezing.py
+++ b/tests/test_currency_network_freezing.py
@@ -44,7 +44,7 @@ def currency_network_contract_with_trustlines(web3, accounts, chain):
     contract = deploy_network(web3, **NETWORK_SETTING)
     for (A, B, clAB, clBA) in trustlines:
         contract.functions.setAccount(
-            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0, 0, 0
+            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0
         ).transact()
 
     return contract
@@ -260,7 +260,7 @@ def test_freezing_trustline_via_set_account(
     network = currency_network_contract_with_trustlines
 
     network.functions.setAccount(
-        accounts[0], accounts[1], 100, 100, 0, 0, True, 0, 0, 0, 12
+        accounts[0], accounts[1], 100, 100, 0, 0, True, 0, 12
     ).transact()
 
     assert network.functions.isTrustlineFrozen(accounts[0], accounts[1]).call() is True
@@ -272,7 +272,7 @@ def test_freezing_trustline_via_set_account_default_interests(
     network = currency_network_contract_with_trustlines
 
     network.functions.setAccountDefaultInterests(
-        accounts[0], accounts[1], 100, 100, True, 0, 0, 0, 12
+        accounts[0], accounts[1], 100, 100, True, 0, 12
     ).transact()
 
     assert network.functions.isTrustlineFrozen(accounts[0], accounts[1]).call() is True

--- a/tests/test_currency_network_interests.py
+++ b/tests/test_currency_network_interests.py
@@ -103,8 +103,6 @@ def test_interests_positive_balance(
         100,
         100,
         False,
-        0,
-        0,
         current_time,
         100000000,
     ).transact()
@@ -140,8 +138,6 @@ def test_interests_high_value(
         2000,
         2000,
         False,
-        0,
-        0,
         current_time,
         1000000000000000000,
     ).transact()
@@ -173,8 +169,6 @@ def test_interests_negative_balance(
         100,
         100,
         False,
-        0,
-        0,
         current_time,
         -100000000,
     ).transact()
@@ -207,8 +201,6 @@ def test_no_interests(
         0,
         0,
         False,
-        0,
-        0,
         current_time,
         100000000,
     ).transact()
@@ -234,7 +226,7 @@ def test_custom_interests(
 
     contract = currency_network_contract_custom_interests_safe_ripple
     contract.functions.setAccount(
-        accounts[0], accounts[1], 0, 2000000000, 0, 1234, False, 0, 0, 0, 0
+        accounts[0], accounts[1], 0, 2000000000, 0, 1234, False, 0, 0
     ).transact()
     current_time = int(time.time())
     chain.time_travel(current_time + SECONDS_PER_YEAR)
@@ -264,17 +256,7 @@ def test_custom_interests_postive_balance(
     current_time = int(time.time())
     chain.time_travel(current_time + 10)
     contract.functions.setAccount(
-        accounts[0],
-        accounts[1],
-        0,
-        2000000000,
-        1234,
-        0,
-        False,
-        0,
-        0,
-        current_time,
-        100000000,
+        accounts[0], accounts[1], 0, 2000000000, 1234, 0, False, current_time, 100000000
     ).transact()
 
     chain.time_travel(current_time + SECONDS_PER_YEAR)
@@ -311,7 +293,7 @@ def test_safe_interest_allows_direct_transactions(
 
     contract = currency_network_contract_custom_interests_safe_ripple
     contract.functions.setAccount(
-        accounts[0], accounts[1], 1000000, 2000000, 100, 200, False, 0, 0, 0, 0
+        accounts[0], accounts[1], 1000000, 2000000, 100, 200, False, 0, 0
     ).transact()
     # setAccount(address, address, creditLimit, creditLimit, interest, interest, feeOut, feeOut, mtime, balance)
 
@@ -332,30 +314,10 @@ def test_safe_interest_allows_transactions_mediated(
     current_time = int(time.time())
     chain.time_travel(current_time + 10)
     contract.functions.setAccount(
-        accounts[0],
-        accounts[1],
-        1000000,
-        2000000,
-        100,
-        200,
-        False,
-        0,
-        0,
-        current_time,
-        0,
+        accounts[0], accounts[1], 1000000, 2000000, 100, 200, False, current_time, 0
     ).transact()
     contract.functions.setAccount(
-        accounts[1],
-        accounts[2],
-        1000000,
-        2000000,
-        100,
-        200,
-        False,
-        0,
-        0,
-        current_time,
-        0,
+        accounts[1], accounts[2], 1000000, 2000000, 100, 200, False, current_time, 0
     ).transact()
     # setAccount(address, address, creditLimit, creditLimit, interest, interest, feeOut, feeOut, mtime, balance)
 
@@ -377,30 +339,10 @@ def test_safe_interest_disallows_transactions_mediated_if_interests_increase(
     current_time = int(time.time())
     chain.time_travel(current_time + 10)
     contract.functions.setAccount(
-        accounts[0],
-        accounts[1],
-        1000000,
-        2000000,
-        200,
-        100,
-        False,
-        0,
-        0,
-        current_time,
-        0,
+        accounts[0], accounts[1], 1000000, 2000000, 200, 100, False, current_time, 0
     ).transact()
     contract.functions.setAccount(
-        accounts[1],
-        accounts[2],
-        1000000,
-        2000000,
-        100,
-        200,
-        False,
-        0,
-        0,
-        current_time,
-        0,
+        accounts[1], accounts[2], 1000000, 2000000, 100, 200, False, current_time, 0
     ).transact()
 
     with pytest.raises(eth_tester.exceptions.TransactionFailed):
@@ -421,30 +363,10 @@ def test_safe_interest_allows_transactions_mediated_solves_imbalance(
     current_time = int(time.time())
     chain.time_travel(current_time + 10)
     contract.functions.setAccount(
-        accounts[0],
-        accounts[1],
-        1000000,
-        2000000,
-        200,
-        100,
-        False,
-        0,
-        0,
-        current_time,
-        100,
+        accounts[0], accounts[1], 1000000, 2000000, 200, 100, False, current_time, 100
     ).transact()
     contract.functions.setAccount(
-        accounts[1],
-        accounts[2],
-        1000000,
-        2000000,
-        100,
-        200,
-        False,
-        0,
-        0,
-        current_time,
-        100,
+        accounts[1], accounts[2], 1000000, 2000000, 100, 200, False, current_time, 100
     ).transact()
 
     getattr(contract.functions, transfer_function_name)(
@@ -464,30 +386,10 @@ def test_safe_interest_disallows_transactions_mediated_solves_imbalance_but_over
     current_time = int(time.time())
     chain.time_travel(current_time + 10)
     contract.functions.setAccount(
-        accounts[0],
-        accounts[1],
-        1000000,
-        2000000,
-        200,
-        100,
-        False,
-        0,
-        0,
-        current_time,
-        100,
+        accounts[0], accounts[1], 1000000, 2000000, 200, 100, False, current_time, 100
     ).transact()
     contract.functions.setAccount(
-        accounts[1],
-        accounts[2],
-        1000000,
-        2000000,
-        100,
-        200,
-        False,
-        0,
-        0,
-        current_time,
-        100,
+        accounts[1], accounts[2], 1000000, 2000000, 100, 200, False, current_time, 100
     ).transact()
 
     with pytest.raises(eth_tester.exceptions.TransactionFailed):
@@ -515,8 +417,6 @@ def test_negative_interests_default_positive_balance(
         -100,
         -100,
         False,
-        0,
-        0,
         current_time,
         100000000,
     ).transact()
@@ -551,8 +451,6 @@ def test_negative_interests_default_negative_balance(
         -100,
         -100,
         False,
-        0,
-        0,
         current_time,
         -100000000,
     ).transact()
@@ -587,8 +485,6 @@ def test_interests_overflow(
         2 ** (INTEREST_WIDTH - 1) - 1,
         2 ** (INTEREST_WIDTH - 1) - 1,
         False,
-        0,
-        0,
         current_time,
         2 ** CREDITLINE_WIDTH - 1,
     ).transact()
@@ -618,8 +514,6 @@ def test_interests_underflow(
         2 ** (INTEREST_WIDTH - 1) - 1,
         2 ** (INTEREST_WIDTH - 1) - 1,
         False,
-        0,
-        0,
         current_time,
         -(2 ** CREDITLINE_WIDTH - 1),
     ).transact()

--- a/tests/test_currency_network_onboarding.py
+++ b/tests/test_currency_network_onboarding.py
@@ -83,7 +83,7 @@ def test_cannot_change_onboarder(currency_network_contract, accounts):
 
 def test_set_account_onboards(currency_network_contract, accounts):
     currency_network_contract.functions.setAccountDefaultInterests(
-        accounts[1], accounts[2], 1, 1, False, 1, 1, 1, 1
+        accounts[1], accounts[2], 1, 1, False, 1, 1
     ).transact()
 
     assert (

--- a/tests/test_currency_network_receiver_pays.py
+++ b/tests/test_currency_network_receiver_pays.py
@@ -28,7 +28,7 @@ def currency_network_contract_with_trustlines(web3, accounts):
     )
     for (A, B, clAB, clBA) in trustlines:
         contract.functions.setAccount(
-            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0, 0, 0
+            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0
         ).transact()
     return contract
 
@@ -46,23 +46,23 @@ def currency_network_contract_with_high_trustlines(web3, accounts):
     )
     creditline = 1000000
     contract.functions.setAccount(
-        accounts[0], accounts[1], creditline, creditline, 0, 0, False, 0, 0, 0, 0
+        accounts[0], accounts[1], creditline, creditline, 0, 0, False, 0, 0
     ).transact()
     contract.functions.setAccount(
-        accounts[1], accounts[2], creditline, creditline, 0, 0, False, 0, 0, 0, 0
+        accounts[1], accounts[2], creditline, creditline, 0, 0, False, 0, 0
     ).transact()
     contract.functions.setAccount(
-        accounts[2], accounts[3], creditline, creditline, 0, 0, False, 0, 0, 0, 0
+        accounts[2], accounts[3], creditline, creditline, 0, 0, False, 0, 0
     ).transact()
 
     contract.functions.setAccount(
-        accounts[0], accounts[2], creditline, creditline, 0, 0, False, 0, 0, 0, 0
+        accounts[0], accounts[2], creditline, creditline, 0, 0, False, 0, 0
     ).transact()
     contract.functions.setAccount(
-        accounts[2], accounts[4], creditline, creditline, 0, 0, False, 0, 0, 0, 0
+        accounts[2], accounts[4], creditline, creditline, 0, 0, False, 0, 0
     ).transact()
     contract.functions.setAccount(
-        accounts[4], accounts[3], creditline, creditline, 0, 0, False, 0, 0, 0, 0
+        accounts[4], accounts[3], creditline, creditline, 0, 0, False, 0, 0
     ).transact()
 
     return contract

--- a/tests/test_exchange.py
+++ b/tests/test_exchange.py
@@ -52,7 +52,7 @@ def currency_network_contract_with_trustlines(web3, exchange_contract, accounts)
     )
     for (A, B, clAB, clBA) in trustlines:
         contract.functions.setAccount(
-            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0, 0, 0
+            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0
         ).transact()
     contract.functions.addAuthorizedAddress(exchange_contract.address).transact()
     return contract

--- a/tests/test_gas_costs.py
+++ b/tests/test_gas_costs.py
@@ -70,7 +70,7 @@ def currency_network_contract_with_trustlines(web3, accounts):
     )
     for (A, B, clAB, clBA) in trustlines:
         contract.functions.setAccount(
-            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 0, 0, 1, 1
+            accounts[A], accounts[B], clAB, clBA, 0, 0, False, 1, 1
         ).transact()
     return contract
 

--- a/tests/test_information_from_events.py
+++ b/tests/test_information_from_events.py
@@ -37,7 +37,7 @@ def currency_network_contract_with_trustlines(web3, accounts):
     contract = deploy_network(web3, **NETWORK_SETTING)
     for (A, B, clAB, clBA) in trustlines:
         contract.functions.setAccountDefaultInterests(
-            accounts[A], accounts[B], clAB, clBA, False, 0, 0, 0, 0
+            accounts[A], accounts[B], clAB, clBA, False, 0, 0
         ).transact()
     return contract
 


### PR DESCRIPTION
The fee fields were originally planned to be used for onboarding
rewards.
This removal is a breaking change, as the number of fields returned by
getAccount will change.