### PR TITLE
Update signature of executeTransaction in identity for new features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,14 @@ all:: compile
 clean::
 	rm -rf build/contracts.json .requirements-installed
 
+lint: install-requirements
+	flake8 tests py-deploy
+	black --check tests py-deploy
+	mypy --ignore-missing-imports tests py-deploy
+
+test:: install
+	pytest tests
+
 .requirements-installed: constraints.txt requirements.txt
 	@echo "===> Installing requirements in your local virtualenv"
 	pip install -q -c constraints.txt -r requirements.txt

--- a/contracts/identity/Identity.sol
+++ b/contracts/identity/Identity.sol
@@ -16,7 +16,7 @@ contract Identity is ProxyStorage {
     uint public gasPriceDivisor = 1000000;
 
     event TransactionExecution(bytes32 hash, bool status);
-    event FeePayment(uint value, address recipient, address currencyNetwork);
+    event FeePayment(uint value, address indexed recipient, address indexed currencyNetwork);
     event ContractDeployment(address deployed);
 
     constructor() public {

--- a/contracts/identity/Identity.sol
+++ b/contracts/identity/Identity.sol
@@ -112,7 +112,7 @@ contract Identity is ProxyStorage {
         if (timeLimit == 0) {
             return true;
         } else {
-            return timeLimit <= now;
+            return timeLimit >= now;
         }
     }
 

--- a/contracts/identity/Identity.sol
+++ b/contracts/identity/Identity.sol
@@ -16,7 +16,7 @@ contract Identity is ProxyStorage {
     mapping(bytes32 => bool) private hashUsed;
     uint public lastNonce = 0;
     // Divides the gas price value to allow for finer range of fee price
-    uint public gasPriceDivisor = 1000000;
+    uint constant public gasPriceDivisor = 1000000;
 
     event TransactionExecution(bytes32 hash, bool status);
     event FeePayment(uint value, address indexed recipient, address indexed currencyNetwork);

--- a/contracts/identity/Identity.sol
+++ b/contracts/identity/Identity.sol
@@ -12,6 +12,8 @@ contract Identity is ProxyStorage {
 
     mapping(bytes32 => bool) private hashUsed;
     uint public lastNonce = 0;
+    // Divides the gas price value to allow for finer range of fee price
+    uint public gasPriceDivisor = 1000000;
 
     event TransactionExecution(bytes32 hash, bool status);
     event FeesPaid(uint value, address currencyNetwork);
@@ -85,7 +87,7 @@ contract Identity is ProxyStorage {
         }
 
         if ((gasPrice > 0 || baseFee > 0) && status != false) {
-            uint256 fees = baseFee + gasSpent * gasPrice;
+            uint256 fees = baseFee + gasSpent * gasPrice / gasPriceDivisor;
             require(fees >= baseFee, "Fees addition overflow");
             DebtTracking debtContract = DebtTracking(currencyNetworkOfFees);
             debtContract.increaseDebt(msg.sender, fees);

--- a/contracts/identity/Identity.sol
+++ b/contracts/identity/Identity.sol
@@ -7,6 +7,8 @@ import "./ProxyStorage.sol";
 
 contract Identity is ProxyStorage {
 
+    uint constant public version  = 1;
+
     address public owner;
     uint public chainId;
     bool public initialised;
@@ -147,7 +149,8 @@ contract Identity is ProxyStorage {
                     byte(0x19),
                     byte(0),
                     address(this),
-                    chainId
+                    chainId,
+                    version
                 ),
                 abi.encodePacked(
                     to,

--- a/contracts/identity/IdentityProxyFactory.sol
+++ b/contracts/identity/IdentityProxyFactory.sol
@@ -9,6 +9,12 @@ contract IdentityProxyFactory {
 
     event ProxyDeployment(address owner, address proxyAddress, address implementationAddress);
 
+    uint public chainId;
+
+    constructor(uint _chainId) public {
+        chainId = _chainId;
+    }
+
     function deployProxy(bytes memory initcode, address implementationAddress, bytes memory signature) public {
         // we need to  check a signature there to make sure the owner authorized this implementationAddress
         address owner;
@@ -30,7 +36,7 @@ contract IdentityProxyFactory {
         }
 
         Proxy(proxyAddress).setImplementation(implementationAddress);
-        Identity(proxyAddress).init(owner);
+        Identity(proxyAddress).init(owner, chainId);
 
         emit ProxyDeployment(owner, proxyAddress, implementationAddress);
     }

--- a/contracts/tests/TestContract.sol
+++ b/contracts/tests/TestContract.sol
@@ -6,12 +6,18 @@ import "../currency-network/DebtTracking.sol";
 // Test contract used for testing identity contract meta transaction features
 contract TestContract is DebtTracking {
 
+    uint public testPublicValue = 123456;
+
     event TestEvent(
         address from,
         uint256 value,
         bytes data,
         int argument
     );
+
+    constructor () public payable {
+
+    }
 
     function increaseDebt(address creditor, uint value) external {
     }

--- a/contracts/tests/TestIdentity.sol
+++ b/contracts/tests/TestIdentity.sol
@@ -18,11 +18,11 @@ contract TestIdentity is Identity {
         uint256 baseFee,
         uint256 gasPrice,
         uint256 gasLimit,
+        address feeRecipient,
         address currencyNetworkOfFees,
         uint256 nonce,
         uint256 timeLimit,
-        uint8 operationType,
-        bytes memory extraHash
+        uint8 operationType
     )
         public
         pure
@@ -36,11 +36,11 @@ contract TestIdentity is Identity {
             baseFee,
             gasPrice,
             gasLimit,
+            feeRecipient,
             currencyNetworkOfFees,
             nonce,
             timeLimit,
-            operationType,
-            extraHash
+            operationType
         );
     }
 }

--- a/contracts/tests/TestIdentity.sol
+++ b/contracts/tests/TestIdentity.sol
@@ -11,7 +11,6 @@ import "../identity/Identity.sol";
 contract TestIdentity is Identity {
 
     function testTransactionHash(
-        address from,
         address to,
         uint256 value,
         bytes memory data,
@@ -25,11 +24,10 @@ contract TestIdentity is Identity {
         uint8 operationType
     )
         public
-        pure
+        view
         returns (bytes32)
     {
         return transactionHash(
-            from,
             to,
             value,
             data,

--- a/contracts/tests/TestIdentity.sol
+++ b/contracts/tests/TestIdentity.sol
@@ -15,9 +15,13 @@ contract TestIdentity is Identity {
         address to,
         uint256 value,
         bytes memory data,
-        uint64 fees,
+        uint256 baseFee,
+        uint256 gasPrice,
+        uint256 gasLimit,
         address currencyNetworkOfFees,
         uint256 nonce,
+        uint256 timeLimit,
+        uint8 operationType,
         bytes memory extraHash
     )
         public
@@ -29,9 +33,13 @@ contract TestIdentity is Identity {
             to,
             value,
             data,
-            fees,
+            baseFee,
+            gasPrice,
+            gasLimit,
             currencyNetworkOfFees,
             nonce,
+            timeLimit,
+            operationType,
             extraHash
         );
     }

--- a/py-deploy/tldeploy/core.py
+++ b/py-deploy/tldeploy/core.py
@@ -192,9 +192,16 @@ def deploy_networks(web3, network_settings, currency_network_contract_name=None)
     return networks, exchange, unw_eth
 
 
-def deploy_identity(web3, owner_address):
+def deploy_identity(web3, owner_address, chain_id=None):
     identity = deploy("Identity", web3=web3)
-    function_call = identity.functions.init(owner_address)
+
+    if chain_id is None:
+        chain_id = get_chain_id(web3)
+    function_call = identity.functions.init(owner_address, chain_id)
     send_function_call_transaction(function_call, web3=web3)
 
     return identity
+
+
+def get_chain_id(web3):
+    return int(web3.eth.chainId)

--- a/py-deploy/tldeploy/identity.py
+++ b/py-deploy/tldeploy/identity.py
@@ -40,11 +40,11 @@ class MetaTransaction:
     base_fee: int = 0
     gas_price: int = 0
     gas_limit: int = 0
+    fee_recipient: str = ZERO_ADDRESS
     currency_network_of_fees: str = attr.ib()
     nonce: Optional[int] = None
     time_limit: int = 0
     operation_type: int = 0
-    extra_data: bytes = bytes()
     signature: Optional[bytes] = None
 
     @currency_network_of_fees.default
@@ -116,10 +116,10 @@ class MetaTransaction:
                 "uint256",
                 "uint256",
                 "address",
+                "address",
                 "uint256",
                 "uint256",
                 "uint8",
-                "bytes",
             ],
             [
                 "0x19",
@@ -131,11 +131,11 @@ class MetaTransaction:
                 self.base_fee,
                 self.gas_price,
                 self.gas_limit,
+                self.fee_recipient,
                 currency_network_of_fees,
                 self.nonce,
                 self.time_limit,
                 self.operation_type,
-                self.extra_data,
             ],
         )
 
@@ -292,11 +292,11 @@ class Delegate:
             signed_meta_transaction.base_fee,
             signed_meta_transaction.gas_price,
             signed_meta_transaction.gas_limit,
+            signed_meta_transaction.fee_recipient,
             signed_meta_transaction.currency_network_of_fees,
             signed_meta_transaction.nonce,
             signed_meta_transaction.time_limit,
             signed_meta_transaction.operation_type,
-            signed_meta_transaction.extra_data,
             signed_meta_transaction.signature,
         )
 

--- a/py-deploy/tldeploy/identity.py
+++ b/py-deploy/tldeploy/identity.py
@@ -178,8 +178,13 @@ class Delegate:
         """Validates the fields of the meta transaction against the state of
         the identity contract.
 
-        This is equivalent to ``` validate_replay_mechanism(tx)
-        validate_signature(tx) Will raise
+        This is equivalent to:
+        ```
+        validate_replay_mechanism(tx)
+        validate_signature(tx)
+        validate_time_limit(tx)
+        ```
+        Will raise
         UnexpectedIdentityContractException, if it could not find the
         check in the contract.
         """

--- a/py-deploy/tldeploy/identity.py
+++ b/py-deploy/tldeploy/identity.py
@@ -17,6 +17,7 @@ from tldeploy.core import deploy, get_contract_interface
 from tldeploy.signing import sign_msg_hash, solidity_keccak
 
 MAX_GAS = 1_000_000
+ZERO_ADDRESS = "0x" + "0" * 40
 
 
 def validate_and_checksum_addresses(addresses):
@@ -33,7 +34,7 @@ def validate_and_checksum_addresses(addresses):
 class MetaTransaction:
 
     from_: Optional[str] = None
-    to: str
+    to: str = ZERO_ADDRESS
     value: int = 0
     data: bytes = bytes()
     base_fee: int = 0

--- a/tests/test_gas_costs.py
+++ b/tests/test_gas_costs.py
@@ -7,7 +7,7 @@
 import pytest
 from texttable import Texttable
 from web3 import Web3
-from tldeploy.core import deploy_network, deploy_identity
+from tldeploy.core import deploy_network, deploy_identity, get_chain_id
 from tldeploy.identity import deploy_proxied_identity
 
 from .conftest import EXTRA_DATA, EXPIRATION_TIME
@@ -85,7 +85,9 @@ def identity_implementation(deploy_contract, web3):
 @pytest.fixture(scope="session")
 def proxy_factory(deploy_contract, web3):
 
-    proxy_factory = deploy_contract("IdentityProxyFactory")
+    proxy_factory = deploy_contract(
+        "IdentityProxyFactory", constructor_args=(get_chain_id(web3),)
+    )
     return proxy_factory
 
 
@@ -228,7 +230,7 @@ def test_deploy_identity(web3, accounts, table):
     for block_number in range(block_number_after, block_number_before, -1):
         gas_cost += web3.eth.getBlock(block_number).gasUsed
 
-    report_gas_costs(table, "Deploy Identity", gas_cost, limit=1_200_000)
+    report_gas_costs(table, "Deploy Identity", gas_cost, limit=1_250_000)
 
 
 def test_deploy_proxied_identity(
@@ -253,4 +255,4 @@ def test_deploy_proxied_identity(
     for block_number in range(block_number_after, block_number_before, -1):
         gas_cost += web3.eth.getBlock(block_number).gasUsed
 
-    report_gas_costs(table, "Deploy Identity", gas_cost, limit=270_000)
+    report_gas_costs(table, "Deploy Proxied Identity", gas_cost, limit=310_000)

--- a/tests/test_gas_costs.py
+++ b/tests/test_gas_costs.py
@@ -228,7 +228,7 @@ def test_deploy_identity(web3, accounts, table):
     for block_number in range(block_number_after, block_number_before, -1):
         gas_cost += web3.eth.getBlock(block_number).gasUsed
 
-    report_gas_costs(table, "Deploy Identity", gas_cost, limit=1_000_000)
+    report_gas_costs(table, "Deploy Identity", gas_cost, limit=1_200_000)
 
 
 def test_deploy_proxied_identity(

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -194,8 +194,8 @@ def test_meta_transaction_signature_corresponds_to_clientlib_signature(
     )
     assert (
         signature.hex()
-        == "a558db2e5282de87128d061dc4fc307d3458791eb0284a318e17609f74928c"
-        "bd03f0793660a42090e9eb12eb74426c98885ce09ddcbea4375f8e48baa273c0e800"
+        == "639db755a4e0642c2ec76485cf623c58b635c54f9ce375088fad40a128779d7a060"
+        "ceb63129eb9681216a844a0577184b1d3266fc6ac00fbbe23e72b592c33c200"
     )
 
 
@@ -919,3 +919,7 @@ def test_meta_transaction_create_contract_fails(
         fromBlock=0
     ).get_all_entries()
     assert len(deploy_events) == 0
+
+
+def test_get_version(test_identity_contract):
+    assert test_identity_contract.functions.version().call() == 1

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -709,7 +709,9 @@ def test_meta_transaction_gas_fee(
     B = accounts[3]
     to = currency_network_contract.address
     base_fee = 123
-    gas_price = 1000
+    effective_gas_price = 1000
+    contract_gas_price_divisor = 10 ** 6
+    gas_price = effective_gas_price * contract_gas_price_divisor
 
     function_call = currency_network_contract.functions.updateCreditlimits(B, 100, 100)
     meta_transaction = identity.filled_and_signed_meta_transaction(
@@ -723,7 +725,7 @@ def test_meta_transaction_gas_fee(
         A, delegate_address
     ).call()
 
-    assert (effective_fee - base_fee) % gas_price == 0
+    assert (effective_fee - base_fee) % effective_gas_price == 0
     assert effective_fee - base_fee != 0
 
 

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -455,7 +455,20 @@ def test_meta_transaction_time_limit_valid(identity, delegate, web3, accounts):
     value = 1000
     time_limit = web3.eth.getBlock("latest").timestamp + 1000
 
-    meta_transaction = MetaTransaction(to=to, value=value, gas_limit=time_limit)
+    meta_transaction = MetaTransaction(to=to, value=value, time_limit=time_limit)
+
+    meta_transaction = identity.filled_and_signed_meta_transaction(meta_transaction)
+    tx_id = delegate.send_signed_meta_transaction(meta_transaction)
+
+    assert get_transaction_status(web3, tx_id)
+
+
+def test_meta_transaction_no_limit_valid(identity, delegate, web3, accounts):
+    to = accounts[2]
+    value = 1000
+    time_limit = 0
+
+    meta_transaction = MetaTransaction(to=to, value=value, time_limit=time_limit)
 
     meta_transaction = identity.filled_and_signed_meta_transaction(meta_transaction)
     tx_id = delegate.send_signed_meta_transaction(meta_transaction)
@@ -466,9 +479,9 @@ def test_meta_transaction_time_limit_valid(identity, delegate, web3, accounts):
 def test_meta_transaction_time_limit_invalid(identity, delegate, web3, accounts):
     to = accounts[2]
     value = 1000
-    time_limit = 456
+    time_limit = web3.eth.getBlock("latest").timestamp - 1
 
-    meta_transaction = MetaTransaction(to=to, value=value, gas_limit=time_limit)
+    meta_transaction = MetaTransaction(to=to, value=value, time_limit=time_limit)
 
     meta_transaction = identity.filled_and_signed_meta_transaction(meta_transaction)
     tx_id = delegate.send_signed_meta_transaction(meta_transaction)

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -817,7 +817,7 @@ def test_meta_transaction_create_contract(
     assert execution_event["hash"] == meta_transaction.hash
     assert execution_event["status"] is True
 
-    deploy_event = identity.contract.events.ContractDeploy.createFilter(
+    deploy_event = identity.contract.events.ContractDeployment.createFilter(
         fromBlock=0
     ).get_all_entries()[0]["args"]
     deployed_contract = web3.eth.contract(
@@ -861,7 +861,7 @@ def test_meta_transaction_create_contract_fails(
     assert execution_event["hash"] == meta_transaction.hash
     assert execution_event["status"] is False
 
-    deploy_events = identity.contract.events.ContractDeploy.createFilter(
+    deploy_events = identity.contract.events.ContractDeployment.createFilter(
         fromBlock=0
     ).get_all_entries()
     assert len(deploy_events) == 0

--- a/tests/test_identity_factory.py
+++ b/tests/test_identity_factory.py
@@ -12,11 +12,16 @@ from tldeploy.identity import (
 from eth_tester.exceptions import TransactionFailed
 
 from .conftest import EXTRA_DATA, EXPIRATION_TIME
-from tldeploy.core import deploy_network
+from tldeploy.core import deploy_network, get_chain_id
 from tldeploy.identity import deploy_proxied_identity, build_create2_address
 
 from deploy_tools.compile import build_initcode
 from deploy_tools.deploy import deploy_compiled_contract
+
+
+@pytest.fixture(scope="session")
+def chain_id(web3):
+    return get_chain_id(web3)
 
 
 @pytest.fixture(scope="session")
@@ -34,7 +39,7 @@ def currency_network_contract(web3):
 
 
 @pytest.fixture(scope="session")
-def proxy_factory(deploy_contract, contract_assets, web3):
+def proxy_factory(deploy_contract, contract_assets, web3, chain_id):
     """Returns a proxy factory deployed at a deterministic address"""
     # We need to create a new account that never sent a transaction
     # to make sure the create1 address of the factory does not depend on other tests or fixtures
@@ -46,6 +51,7 @@ def proxy_factory(deploy_contract, contract_assets, web3):
     proxy_factory = deploy_compiled_contract(
         abi=contract_assets["IdentityProxyFactory"]["abi"],
         bytecode=contract_assets["IdentityProxyFactory"]["bytecode"],
+        constructor_args=(chain_id,),
         web3=web3,
         private_key=new_account.key,
     )

--- a/tests/test_identity_factory.py
+++ b/tests/test_identity_factory.py
@@ -310,7 +310,8 @@ def test_change_identity_implementation(
     meta_transaction = proxied_identity.filled_and_signed_meta_transaction(
         meta_transaction
     )
-    delegate.send_signed_meta_transaction(meta_transaction)
+
+    delegate.send_signed_meta_transaction(meta_transaction, gas=None)
 
     assert (
         proxy_contract_with_owner.functions.implementation().call()
@@ -382,3 +383,7 @@ def test_deploy_identity_proxy(
 
     assert proxy.address == pre_computed_address
     assert proxy.functions.implementation().call() == identity_implementation.address
+
+
+def test_get_version(proxied_identity_contract_with_owner):
+    assert proxied_identity_contract_with_owner.functions.version().call() == 1


### PR DESCRIPTION
I had to remove the `success` return value of `executeTransaction` because of stack too deep problem.

Breaks the interface of the identity contract so breaks the end2end tests.

closes: https://github.com/trustlines-protocol/contracts/issues/290