### PR TITLE
Add function to execute a meta-tx from owner without signature

### DIFF
--- a/contracts/identity/Identity.sol
+++ b/contracts/identity/Identity.sol
@@ -110,6 +110,26 @@ contract Identity is ProxyStorage {
         emit TransactionExecution(hash, status);
     }
 
+    function executeOwnerTransaction(
+        address payable to,
+        uint256 value,
+        bytes memory data,
+        uint8 operationType
+    )
+        public
+    {
+        require(msg.sender == owner, "Only owner can call this");
+        bool status = applyOperation(
+            to,
+            value,
+            data,
+            operationType,
+            gasleft()
+        );
+
+        require(status, "Transaction execution failed");
+    }
+
     function validateNonce(uint nonce, bytes32 hash) public view returns (bool) {
         if (nonce == 0) {
             return !hashUsed[hash];

--- a/contracts/identity/Identity.sol
+++ b/contracts/identity/Identity.sol
@@ -114,17 +114,20 @@ contract Identity is ProxyStorage {
         address payable to,
         uint256 value,
         bytes memory data,
+        uint256 timeLimit,
         uint8 operationType
     )
         public
     {
         require(msg.sender == owner, "Only owner can call this");
+        require(validateTimeLimit(timeLimit), "The transaction expired");
+
         bool status = applyOperation(
             to,
             value,
             data,
             operationType,
-            gasleft()
+            uint(-1)
         );
 
         require(status, "Transaction execution failed");

--- a/tests/identity/test_identity.py
+++ b/tests/identity/test_identity.py
@@ -973,13 +973,36 @@ def test_get_version(each_identity_contract):
     assert each_identity_contract.functions.version().call() == 1
 
 
-def test_execute_owner_transaction(owner, accounts, test_identity_contract, web3):
+def test_execute_owner_transaction(owner, accounts, identity_contract, web3):
     recipient = accounts[1]
     transfer_value = 123
     initial_recipient_balance = web3.eth.getBalance(recipient)
-    test_identity_contract.functions.executeOwnerTransaction(
-        recipient, transfer_value, b"", 0
+    identity_contract.functions.executeOwnerTransaction(
+        recipient, transfer_value, b"", 0, 0
     ).transact({"from": owner})
     post_recipient_balance = web3.eth.getBalance(recipient)
 
     assert post_recipient_balance - initial_recipient_balance == transfer_value
+
+
+def test_execute_owner_transaction_below_time_limit(
+    owner, accounts, identity_contract, web3
+):
+    recipient = accounts[1]
+    transfer_value = 123
+    time_limit = web3.eth.getBlock("latest").timestamp + 100
+    identity_contract.functions.executeOwnerTransaction(
+        recipient, transfer_value, b"", time_limit, 0
+    ).transact({"from": owner})
+
+
+def test_execute_owner_transaction_expired_time_limit(
+    owner, accounts, identity_contract, web3
+):
+    recipient = accounts[1]
+    transfer_value = 123
+    time_limit = web3.eth.getBlock("latest").timestamp - 1
+    with pytest.raises(TransactionFailed):
+        identity_contract.functions.executeOwnerTransaction(
+            recipient, transfer_value, b"", time_limit, 0
+        ).transact({"from": owner})

--- a/tests/identity/test_identity.py
+++ b/tests/identity/test_identity.py
@@ -971,3 +971,15 @@ def test_meta_transaction_create_contract_fails(
 
 def test_get_version(each_identity_contract):
     assert each_identity_contract.functions.version().call() == 1
+
+
+def test_execute_owner_transaction(owner, accounts, test_identity_contract, web3):
+    recipient = accounts[1]
+    transfer_value = 123
+    initial_recipient_balance = web3.eth.getBalance(recipient)
+    test_identity_contract.functions.executeOwnerTransaction(
+        recipient, transfer_value, b"", 0
+    ).transact({"from": owner})
+    post_recipient_balance = web3.eth.getBalance(recipient)
+
+    assert post_recipient_balance - initial_recipient_balance == transfer_value

--- a/tests/test_gas_costs.py
+++ b/tests/test_gas_costs.py
@@ -230,7 +230,7 @@ def test_deploy_identity(web3, accounts, table):
     for block_number in range(block_number_after, block_number_before, -1):
         gas_cost += web3.eth.getBlock(block_number).gasUsed
 
-    report_gas_costs(table, "Deploy Identity", gas_cost, limit=1_400_000)
+    report_gas_costs(table, "Deploy Identity", gas_cost, limit=1_500_000)
 
 
 def test_deploy_proxied_identity(


### PR DESCRIPTION
I considered that user of this function wants the regular ethereum tx flow and just revert and fail the outer transaction in case the inner tx fails. They can then check whether the outer tx failed if they want the status.

The other choice is letting the tx succeed and emit an event with the status to be closer to what `executeTransaction` does.