### PR TITLE
Index meta transaction hash in execution events

### DIFF
--- a/contracts/identity/Identity.sol
+++ b/contracts/identity/Identity.sol
@@ -28,8 +28,8 @@ contract Identity is ProxyStorage {
     // Divides the gas price value to allow for finer range of fee price
     uint constant public gasPriceDivisor = 1000000;
 
-    event TransactionExecution(bytes32 hash, bool status);
-    event TransactionCancellation(bytes32 hash);
+    event TransactionExecution(bytes32 indexed hash, bool status);
+    event TransactionCancellation(bytes32 indexed hash);
     event FeePayment(uint value, address indexed recipient, address indexed currencyNetwork);
     event ContractDeployment(address deployed);
 
@@ -43,9 +43,10 @@ contract Identity is ProxyStorage {
 
     function init(address _owner, uint _chainId) public {
         require(! initialised, "The contract has already been initialised.");
+        initialised = true;
+
         owner = _owner;
         chainId = _chainId;
-        initialised = true;
     }
 
 

--- a/tests/identity/test_gas_costs_identity.py
+++ b/tests/identity/test_gas_costs_identity.py
@@ -87,7 +87,7 @@ def test_meta_tx_over_regular_tx_overhead(
     overhead = gas_cost_meta_tx - gas_cost_regular_tx
 
     report_gas_costs(
-        table, "Overhead of unproxied meta-tx over regular tx", overhead, limit=26700
+        table, "Overhead of unproxied meta-tx over regular tx", overhead, limit=26750
     )
 
 


### PR DESCRIPTION
Index the meta transaction hash in execution events
to be able to search for them more efficient.