### PR TITLE
Changelog 1.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 ==========
 Change Log
 ==========
+`1.1.1`_ (2020-02-25)
+-----------------------
+* Add function of Delegate `get_meta_transaction_status`
+
+
 `1.1.0`_ (2020-02-17)
 -----------------------
 * Add `timeLimit`, `operationType`, and `feeRecipient` to signature of `executeTransaction` (BREAKING)
@@ -226,4 +231,5 @@ The rest of the changes are only interesting for developers:
 .. _0.10.0: https://github.com/trustlines-protocol/contracts/compare/0.9.3...0.10.0
 .. _0.10.1: https://github.com/trustlines-protocol/contracts/compare/0.10.0...0.10.1
 .. _1.0.0: https://github.com/trustlines-protocol/contracts/compare/0.10.1...1.0.0
-.. _1.1.0: https://github.com/trustlines-protocol/contracts/compare/1.0.0...master
+.. _1.1.0: https://github.com/trustlines-protocol/contracts/compare/1.0.0...1.1.0
+.. _1.1.1: https://github.com/trustlines-protocol/contracts/compare/1.1.0...master

--- a/py-deploy/setup.py
+++ b/py-deploy/setup.py
@@ -47,7 +47,7 @@ setup(
     install_requires=[
         "web3>=4.7.1",
         "click>=7.0",
-        "trustlines-contracts-bin>=1.1.0,<2.0.0",
+        "trustlines-contracts-bin>=1.1.1,<2.0.0",
         "contract-deploy-tools>=0.6.1",
         "attrs>=18.2",
         "pendulum>=2.0.0",


### PR DESCRIPTION
Need to release a new version to make https://github.com/trustlines-protocol/relay/pull/426 work.