### PR TITLE
Fix/make compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,51 @@
-VIRTUALENV ?= python3 -m venv
+VIRTUAL_ENV ?= $(shell pwd)/venv
 
 all:: compile
 
 clean::
 	rm -rf build/contracts.json .requirements-installed
 
-lint: install-requirements
-	flake8 tests py-deploy
-	black --check tests py-deploy
-	mypy --ignore-missing-imports tests py-deploy
+lint: setup-venv install-requirements
+	$(VIRTUAL_ENV)/bin/flake8 tests py-deploy
+	$(VIRTUAL_ENV)/bin/black --check tests py-deploy
+	$(VIRTUAL_ENV)/bin/mypy --ignore-missing-imports tests py-deploy
 
-test:: install
-	pytest tests
+test:: setup-venv install
+	$(VIRTUAL_ENV)/bin/pytest tests
 
-.requirements-installed: dev-requirements.txt
+.requirements-installed: setup-venv dev-requirements.txt
 	@echo "===> Installing requirements in your local virtualenv"
-	pip install -q -r dev-requirements.txt
+	$(VIRTUAL_ENV)/bin/pip install -q -r dev-requirements.txt
 	@echo "This file controls for make if the requirements in your virtual env are up to date" > $@
 
 install-requirements:: .requirements-installed
 
-compile:: install-requirements
+compile:: setup-venv install-requirements
 	@echo "==> Compiling contracts"
-	deploy-tools compile --optimize
+	$(VIRTUAL_ENV)/bin/deploy-tools compile --optimize
 	cp -p build/contracts.json py-bin/
 
 install0:: SETUPTOOLS_SCM_PRETEND_VERSION = $(shell python3 -c 'from setuptools_scm import get_version; print(get_version())')
-install0:: compile
+install0:: setup-venv compile
 	@echo "==> Installing py-bin/py-deploy into your local virtualenv"
-	/usr/bin/env SETUPTOOLS_SCM_PRETEND_VERSION=$(SETUPTOOLS_SCM_PRETEND_VERSION) pip install ./py-bin
-	/usr/bin/env SETUPTOOLS_SCM_PRETEND_VERSION=$(SETUPTOOLS_SCM_PRETEND_VERSION) pip install $(PIP_DEPLOY_OPTIONS) ./py-deploy
+	/usr/bin/env SETUPTOOLS_SCM_PRETEND_VERSION=$(SETUPTOOLS_SCM_PRETEND_VERSION) $(VIRTUAL_ENV)/bin/pip install ./py-bin
+	/usr/bin/env SETUPTOOLS_SCM_PRETEND_VERSION=$(SETUPTOOLS_SCM_PRETEND_VERSION) $(VIRTUAL_ENV)/bin/pip install $(PIP_DEPLOY_OPTIONS) ./py-deploy
 
 dist:: compile
 	cd py-bin; python setup.py sdist
 	cd py-deploy; python setup.py sdist
 
 install:: PIP_DEPLOY_OPTIONS = -q -e
-install:: install-requirements install0
+install:: setup-venv install-requirements install0
 
 install-non-editable:: PIP_DEPLOY_OPTIONS = -q
-install-non-editable:: install-requirements install0
+install-non-editable:: setup-venv install-requirements install0
+
+$(VIRTUAL_ENV):
+	@echo "==> Creating virtualenv in $(VIRTUAL_ENV)"
+	python3 -m venv $@
+
+setup-venv: $(VIRTUAL_ENV)
+	@echo "==> Using virtualenv in $(VIRTUAL_ENV)"
+
+.PHONY: setup-venv

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ compile:: setup-venv install-requirements
 	@echo "==> Compiling contracts"
 	$(VIRTUAL_ENV)/bin/deploy-tools compile --optimize
 	cp -p build/contracts.json py-bin/
+	cp -p build/contracts.json $(VIRTUAL_ENV)/trustlines-contracts/build/
+
 
 install0:: SETUPTOOLS_SCM_PRETEND_VERSION = $(shell python3 -c 'from setuptools_scm import get_version; print(get_version())')
 install0:: setup-venv compile


### PR DESCRIPTION
Closes: https://github.com/trustlines-protocol/contracts/issues/321

The deploy-tool does not use `./build/contracts.json` for deployment but `./venv/trustlines-contracts/build/contracts.json` which I guess makes sense since it is the contracts that are packed with the `trustlines-contracts-bin` package that is a requirement for the `trustlines-contracts-deploy` package.

Instead of trying to change that, I copy the compiled contracts to `./venv/trustlines-contracts/build/contracts.json` when running `make compile`.

This required the makefile to be aware of the used venv so I adapted it to make sure a venv is used, using the blockchain repo as example.