### PR TITLE
Change to revert when attempting zero tl update

### DIFF
--- a/contracts/currency-network/CurrencyNetworkBasic.sol
+++ b/contracts/currency-network/CurrencyNetworkBasic.sol
@@ -898,7 +898,7 @@ contract CurrencyNetworkBasic is CurrencyNetworkInterface, MetaData, Authorizabl
                 trustlineAgreement.interestRateReceived == 0 &&
                 trustlineAgreement.isFrozen == false
             ) {
-                return;
+                revert("Can not open zero trustline.");
             }
             _deleteTrustlineRequest(_creditor, _debtor);
             _setTrustline(

--- a/tests/currency_network/test_currency_network_basics.py
+++ b/tests/currency_network/test_currency_network_basics.py
@@ -376,6 +376,17 @@ def test_can_always_reduce(currency_network_adapter_with_trustlines, accounts):
     )
 
 
+def test_update_cannot_open_zero_trustline(currency_network_adapter, accounts):
+    A, C, *rest = accounts
+
+    with pytest.raises(eth_tester.exceptions.TransactionFailed):
+        currency_network_adapter.update_trustline(
+            A, C, creditline_given=0, creditline_received=0
+        )
+
+    assert currency_network_adapter.events("TrustlineUpdate") == []
+
+
 def test_update_without_accept_trustline(currency_network_adapter, accounts):
     A, B, *rest = accounts
 

--- a/tests/currency_network/test_currency_network_interests.py
+++ b/tests/currency_network/test_currency_network_interests.py
@@ -848,7 +848,6 @@ def test_apply_interests_not_possible_when_frozen(
     )
     A, B, *rest = accounts
 
-    adapter.update_trustline(A, B, accept=True)
     # should be fine
     adapter.contract.functions.applyInterests(B).transact({"from": A})
 

--- a/tests/currency_network/test_currency_network_onboarding.py
+++ b/tests/currency_network/test_currency_network_onboarding.py
@@ -1,4 +1,5 @@
 import pytest
+from eth_tester.exceptions import TransactionFailed
 
 from tldeploy.core import deploy_network
 from tests.conftest import EXPIRATION_TIME
@@ -128,9 +129,11 @@ def test_onboarding_event_with_onboarder(currency_network_contract, web3, accoun
 def test_onboarding_no_accept_tl(currency_network_contract, accounts):
     """Test that users cannot attempt to open a TL with (0, 0, 0, 0) to onboard someone"""
     open_trustline(currency_network_contract, accounts[1], accounts[2])
-    currency_network_contract.functions.updateCreditlimits(accounts[3], 0, 0).transact(
-        {"from": accounts[1]}
-    )
+
+    with pytest.raises(TransactionFailed):
+        currency_network_contract.functions.updateCreditlimits(
+            accounts[3], 0, 0
+        ).transact({"from": accounts[1]})
 
     assert (
         currency_network_contract.functions.onboarder(accounts[3]).call() == ADDRESS_0


### PR DESCRIPTION
Currently we were just returning without changing the trustline when an
attempt was made to change the trustlines from all zero to all zero.
This worked fine, but meant that you would not get an event and not a
failed transaction, which would mean no user feedback on what happend.
This now will instead revert, so giving a user feedback that this is not
possible.