### PR TITLE
Add package tlbin to load contracts.json

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,11 +3,14 @@ Change Log
 ==========
 `next`_ (unreleased)
 -----------------------
+* Add means to get contracts.json from py-bin: `from tlbin import load_packaged_contracts`
+* Remove: No longer packs `contracts.json` as data file in `trustlines-contracts/build/`.
+  Use package `tlbin` instead (BREAKING)
 
 `1.1.4`_ (2020-04-15)
 -----------------------
 * Fix bug in interests calculations that would cause the balance to flip sign for big values of negative interests.
-Set the balance to 0 when this should happen instead.
+  Set the balance to 0 when this should happen instead.
 
 `1.1.3`_ (2020-02-28)
 -----------------------

--- a/Makefile
+++ b/Makefile
@@ -28,15 +28,15 @@ compile:: install-requirements
 install0:: SETUPTOOLS_SCM_PRETEND_VERSION = $(shell python3 -c 'from setuptools_scm import get_version; print(get_version())')
 install0:: compile
 	@echo "==> Installing py-bin/py-deploy into your local virtualenv"
-	/usr/bin/env SETUPTOOLS_SCM_PRETEND_VERSION=$(SETUPTOOLS_SCM_PRETEND_VERSION) pip install ./py-bin
-	/usr/bin/env SETUPTOOLS_SCM_PRETEND_VERSION=$(SETUPTOOLS_SCM_PRETEND_VERSION) pip install $(PIP_DEPLOY_OPTIONS) ./py-deploy
+	/usr/bin/env SETUPTOOLS_SCM_PRETEND_VERSION=$(SETUPTOOLS_SCM_PRETEND_VERSION) pip install $(PIP_INSTALL_OPTIONS) ./py-bin
+	/usr/bin/env SETUPTOOLS_SCM_PRETEND_VERSION=$(SETUPTOOLS_SCM_PRETEND_VERSION) pip install $(PIP_INSTALL_OPTIONS) ./py-deploy
 
 dist:: compile
 	cd py-bin; python setup.py sdist
 	cd py-deploy; python setup.py sdist
 
-install:: PIP_DEPLOY_OPTIONS = -q -e
+install:: PIP_INSTALL_OPTIONS = -q -e
 install:: install-requirements install0
 
-install-non-editable:: PIP_DEPLOY_OPTIONS = -q
+install-non-editable:: PIP_INSTALL_OPTIONS = -q
 install-non-editable:: install-requirements install0

--- a/py-bin/README.md
+++ b/py-bin/README.md
@@ -1,0 +1,12 @@
+# Py-Bin
+
+This directory contains an npm and a python package used to pack the `contracts.json` file containing among other things
+the abi and bytecode of all compiled contracts from this repository.
+
+The `tlbin` python package can be used to easily load the `contracts.json` with the following:
+
+```python
+from tlbin import load_packaged_contracts
+
+contracts_dict = load_packaged_contracts()
+```

--- a/py-bin/setup.py
+++ b/py-bin/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 # To use a consistent encoding
 from codecs import open
@@ -8,7 +8,7 @@ here = path.abspath(path.dirname(__file__))
 
 
 # Get the long description from the README file
-with open(path.join(here, "README.rst"), encoding="utf-8") as f:
+with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
@@ -45,7 +45,7 @@ setup(
     keywords="trustlines",
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=[],
+    packages=find_packages(exclude=["contrib", "docs", "tests"]),
     install_requires=[],
     # Although 'package_data' is the preferred approach, in some case you may
     # need to place data files outside of your packages. See:

--- a/py-bin/tlbin/__init__.py
+++ b/py-bin/tlbin/__init__.py
@@ -1,0 +1,1 @@
+from .contracts import load_packaged_contracts  # noqa: F401

--- a/py-bin/tlbin/contracts.py
+++ b/py-bin/tlbin/contracts.py
@@ -1,0 +1,10 @@
+import json
+import os
+import sys
+
+
+def load_packaged_contracts():
+    with open(
+        os.path.join(sys.prefix, "trustlines-contracts", "build", "contracts.json")
+    ) as file:
+        return json.load(file)

--- a/py-deploy/tldeploy/core.py
+++ b/py-deploy/tldeploy/core.py
@@ -3,9 +3,6 @@
 # contracts when running tests in this project.
 
 import collections
-import json
-import os
-import sys
 from typing import Dict
 
 from deploy_tools import deploy_compiled_contract
@@ -14,24 +11,15 @@ from deploy_tools.deploy import (
     send_function_call_transaction,
 )
 from web3 import Web3
-
-
-def load_contracts_json():
-    path = os.environ.get("TRUSTLINES_CONTRACTS_JSON") or os.path.join(
-        sys.prefix, "trustlines-contracts", "build", "contracts.json"
-    )
-    with open(path, "rb") as f:
-        return json.load(f)
+from tlbin import load_packaged_contracts
 
 
 # lazily load the contracts, so the compile_contracts fixture has a chance to
 # set TRUSTLINES_CONTRACTS_JSON
-
-
 class LazyContractsLoader(collections.UserDict):
     def __getitem__(self, *args):
         if not self.data:
-            self.data = load_contracts_json()
+            self.data = load_packaged_contracts()
         return super().__getitem__(*args)
 
 


### PR DESCRIPTION
This package installed in editable mode by make enable the feature
that running `make compile` will provide the newly compiled contracts
to tldeploy that uses tlbin to load the contracts.