### PR TITLE
Fix the setup.py by adding missing long_description_content_type

### DIFF
--- a/py-bin/setup.py
+++ b/py-bin/setup.py
@@ -16,6 +16,7 @@ setup(
     setup_requires=["setuptools_scm"],
     use_scm_version={"root": ".."},
     description="Smart Contracts for Trustlines-Network",
+    long_description_content_type="text/markdown",
     long_description=long_description,
     # The project's main homepage.
     url="https://github.com/trustlines-protocol/contracts",

--- a/py-deploy/setup.py
+++ b/py-deploy/setup.py
@@ -16,6 +16,7 @@ setup(
     setup_requires=["setuptools_scm"],
     use_scm_version={"root": ".."},
     description="deploy trustlines contracts",
+    long_description_content_type="text/markdown",
     long_description=long_description,
     url="https://github.com/trustlines-protocol/contracts",
     author="Trustlines-Network",

--- a/py-deploy/tldeploy/core.py
+++ b/py-deploy/tldeploy/core.py
@@ -3,6 +3,9 @@
 # contracts when running tests in this project.
 
 import collections
+import json
+import os
+import sys
 from typing import Dict
 
 from deploy_tools import deploy_compiled_contract
@@ -11,7 +14,14 @@ from deploy_tools.deploy import (
     send_function_call_transaction,
 )
 from web3 import Web3
-from tlbin import load_packaged_contracts
+
+
+def load_contracts_json():
+    path = os.environ.get("TRUSTLINES_CONTRACTS_JSON") or os.path.join(
+        sys.prefix, "trustlines-contracts", "build", "contracts.json"
+    )
+    with open(path, "rb") as f:
+        return json.load(f)
 
 
 # lazily load the contracts, so the compile_contracts fixture has a chance to
@@ -19,7 +29,7 @@ from tlbin import load_packaged_contracts
 class LazyContractsLoader(collections.UserDict):
     def __getitem__(self, *args):
         if not self.data:
-            self.data = load_packaged_contracts()
+            self.data = load_contracts_json()
         return super().__getitem__(*args)
 
 


### PR DESCRIPTION
Revert the changes of pydeploy to make it compatible again with
old version of pybin