### PR TITLE
Add command to upgrade twince in cicrcleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,10 @@ jobs:
           at: '~'
       - config-path
       - run:
+          name: upgrade twine
+          command: |
+            - pip install --upgrade twine
+      - run:
           name: Init .pypirc
           command: |
             echo -e "[pypi]" >> ~/.pypirc


### PR DESCRIPTION
It seems twine is not up to date on the builder and that makes uploading the dists fail.
https://app.circleci.com/pipelines/github/trustlines-protocol/contracts/453/workflows/b2c3597c-45b2-412b-9c19-12eb8b330fd4/jobs/4079
https://stackoverflow.com/questions/49806586/twine-upload-typeerror-expected-string-or-bytes-like-object