### PR TITLE
Fix packing of contracts.json in py-bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,5 @@ target/
 
 #project
 networks
-/py-bin/contracts.json
+/py-bin/tlbin/contracts.json
 /.requirements-installed

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install-requirements:: .requirements-installed
 compile:: install-requirements
 	@echo "==> Compiling contracts"
 	deploy-tools compile --optimize
-	cp -p build/contracts.json py-bin/
+	cp -p build/contracts.json py-bin/tlbin
 
 install0:: SETUPTOOLS_SCM_PRETEND_VERSION = $(shell python3 -c 'from setuptools_scm import get_version; print(get_version())')
 install0:: compile

--- a/py-bin/index.js
+++ b/py-bin/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./contracts.json')
+module.exports = require('./tlbin/contracts.json')

--- a/py-bin/setup.py
+++ b/py-bin/setup.py
@@ -52,5 +52,6 @@ setup(
     # need to place data files outside of your packages. See:
     # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
     # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-    data_files=[("trustlines-contracts/build", ["contracts.json"])],
+    data_files=[("trustlines-contracts/build", ["tlbin/contracts.json"])],
+    package_data={"tlbin": ["contracts.json"]},
 )

--- a/py-bin/tlbin/contracts.py
+++ b/py-bin/tlbin/contracts.py
@@ -1,10 +1,8 @@
 import json
-import os
-import sys
+
+import pkg_resources
 
 
 def load_packaged_contracts():
-    with open(
-        os.path.join(sys.prefix, "trustlines-contracts", "build", "contracts.json")
-    ) as file:
+    with open(pkg_resources.resource_filename(__name__, "contracts.json")) as file:
         return json.load(file)


### PR DESCRIPTION
This makes it so that you can load the contracts.json even when py-bin is installed in editable mode.
If you install it in editable mode, the data files that should be copied with `data_files=[("trustlines-contracts/build", ["tlbin/contracts.json"])]` are not copied (because that's the stupid way it works). And then the loader cannot find the `contracts.json` to load.

Now the contracts will be packed right next to `contracts.py` thanks to `package_data={"tlbin": ["contracts.json"]}`.

I keep the previous way of packing the contracts for backward compatibility.
