### PR TITLE
Fix publishing to npm

### DIFF
--- a/py-bin/package.json
+++ b/py-bin/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@trustlines/trustlines-contracts-abi",
   "version": "0.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "ABI of the trustlines smart contracts",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
By default scoped packages have privite visibility, which was preventing us from publishing on npm.