### PR TITLE
Restrict balance with negative interests to old balance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,9 @@ Change Log
 ==========
 `next`_ (unreleased)
 -----------------------
+* Updated: limit interest rates in currency networks to `+-20%`
+* Updated: limit balance with negative interests to old balance to avoid increasing the balance
+  instead of lowering it when calculation fails
 
 `1.1.7`_ (2020-10-12)
 -----------------------

--- a/contracts/currency-network/CurrencyNetworkBasic.sol
+++ b/contracts/currency-network/CurrencyNetworkBasic.sol
@@ -1212,18 +1212,20 @@ contract CurrencyNetworkBasic is CurrencyNetworkInterface, MetaData, Authorizabl
 
         // Restrict balance within MAX / MIN balance
         // If rate is negative, we assume that the balance was eventually going to be 0
-        if (newBalance > MAX_BALANCE) {
-            if (rate < 0) {
-                newBalance = 0;
-            } else {
+        if (rate > 0) {
+            if (newBalance > MAX_BALANCE) {
                 newBalance = MAX_BALANCE;
             }
-        }
-        if (newBalance < MIN_BALANCE) {
-            if (rate < 0) {
-                newBalance = 0;
-            } else {
+            if (newBalance < MIN_BALANCE) {
                 newBalance = MIN_BALANCE;
+            }
+        }
+        if (rate < 0) {
+            if (_balance > 0 && newBalance > _balance) {
+                newBalance = 0;
+            }
+            if (_balance < 0 && newBalance < _balance) {
+                newBalance = 0;
             }
         }
         // If sign flipped because of wrong calculation, the best thing we can do is to assume the result should be 0


### PR DESCRIPTION
Previously the new balance was restricted by min/max balance
but should be restricted by old balance instead to prevent that
negative interest rates actually result in a growing balance