### PR TITLE
Properly get the `isFrozen` status of trustlines for migration

### DIFF
--- a/contracts/tests/TestCurrencyNetwork.sol
+++ b/contracts/tests/TestCurrencyNetwork.sol
@@ -203,6 +203,18 @@ contract TestCurrencyNetwork is CurrencyNetwork {
         addToUsersAndFriends(_a, _b);
         _applyOnboardingRules(_a, NO_ONBOARDER);
         _applyOnboardingRules(_b, NO_ONBOARDER);
+
+        emit TrustlineUpdate(
+            _a,
+            _b,
+            _creditlineGiven,
+            _creditlineReceived,
+            _interestRateGiven,
+            _interestRateReceived,
+            _isFrozen
+        );
+        // Be aware that a BalanceUpdate event is missing, as it would not inform about the balance
+        // at the correct `_mtime` since `_mtime` is not an argument of the event.
     }
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -356,6 +356,12 @@ class CurrencyNetworkAdapter:
         function_call = self.contract.functions.freezeNetwork()
         self._transact_with_function_call(function_call, should_fail=should_fail)
 
+    def freeze_network_if_not_frozen(self, should_fail=False):
+        if self.contract.functions.isNetworkFrozen().call():
+            return
+        function_call = self.contract.functions.freezeNetwork()
+        self._transact_with_function_call(function_call, should_fail=should_fail)
+
     def unfreeze_network(self, transaction_options=None, should_fail=False):
         function_call = self.contract.functions.unFreezeNetwork()
         self._transact_with_function_call(
@@ -364,8 +370,13 @@ class CurrencyNetworkAdapter:
             should_fail=should_fail,
         )
 
-    def events(self, event_name: str):
-        return list(getattr(self.contract.events, event_name).getLogs(fromBlock=0))
+    def is_trustline_frozen(self, a, b):
+        return self.contract.functions.isTrustlineFrozen(a, b).call()
+
+    def events(self, event_name: str, from_block: int = 0):
+        return list(
+            getattr(self.contract.events, event_name).getLogs(fromBlock=from_block)
+        )
 
     def _transact_with_function_call(
         self, function_call, transaction_options=None, should_fail=False

--- a/tests/currency_network/test_currency_network_basics.py
+++ b/tests/currency_network/test_currency_network_basics.py
@@ -458,6 +458,7 @@ def test_cannot_accept_old_trustline(currency_network_adapter, accounts):
     "new_creditlimit_given, new_creditlmit_received", [(99, 150), (0, 0)]
 )
 def test_update_reduce_need_no_accept_trustline(
+    web3,
     currency_network_adapter_with_trustlines,
     accounts,
     new_creditlimit_given,
@@ -478,9 +479,9 @@ def test_update_reduce_need_no_accept_trustline(
     assert currency_network_adapter.creditline(A, B) == new_creditlimit_given
     assert currency_network_adapter.creditline(B, A) == new_creditlmit_received
     assert (
-        currency_network_adapter.events("TrustlineUpdate")[0]["args"][
-            "_creditlineGiven"
-        ]
+        currency_network_adapter.events(
+            "TrustlineUpdate", from_block=web3.eth.blockNumber
+        )[0]["args"]["_creditlineGiven"]
         == new_creditlimit_given
     )
 

--- a/tests/currency_network/test_currency_network_freezing.py
+++ b/tests/currency_network/test_currency_network_freezing.py
@@ -323,10 +323,10 @@ def test_freezing_trustline_event(
     )
 
     trustline_update_request_event = network.events.TrustlineUpdateRequest.createFilter(
-        fromBlock=initial_block
+        fromBlock=initial_block + 1
     ).get_all_entries()[0]
     trustline_update_event = network.events.TrustlineUpdate.createFilter(
-        fromBlock=initial_block
+        fromBlock=initial_block + 1
     ).get_all_entries()[0]
 
     assert trustline_update_event["args"]["_debtor"] == accounts[0]


### PR DESCRIPTION
Before, we got this value from a `getAccount` call on the contract,
but this always return `true` if the network is frozen.
Now uses event to get last trustline update event and get `isFrozen`
value from event.