### PR TITLE
Trick gnosis safe to work with our debt tracking

### DIFF
--- a/contracts/currency-network/version3/CurrencyNetworkV3.sol
+++ b/contracts/currency-network/version3/CurrencyNetworkV3.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.8.0;
+
+import "../version2/CurrencyNetworkV2.sol";
+
+/**
+ * CurrencyNetwork
+ *
+ * Extends basic currency networks to add debt tracking, debit transfer, and onboarding.
+ *
+ **/
+contract CurrencyNetworkV3 is CurrencyNetworkV2 {
+
+    /**
+     * A small trick to make the contracts compatible with GnosisSafe
+     * delegate payments.
+     *
+     * @param _creditor The address towards which msg.sender increases its debt
+     * @param _value The value to increase the debt by
+     **/
+    function transfer(address _creditor, uint256 _value) external {
+        increaseDebt(_creditor, _value);
+    }
+}
+
+// SPDX-License-Identifier: MIT


### PR DESCRIPTION
Currently our identity calls the increaseDebt function when we call executeTransaction. This cannot work with gnosisSafe, but it appears that there is a workaround.
https://github.com/safe-global/safe-contracts/blob/da66b45ec87d2fb6da7dfd837b29eacdb9a604c5/contracts/common/SecuredTokenTransfer.sol

We could use a gasToken and increase the debt toward the delegate. Kind of hacky, but seems better than having to do a multi send for this.